### PR TITLE
Fix for FixWpStubs polyfill method

### DIFF
--- a/src/Composer/FixWpStubs.php
+++ b/src/Composer/FixWpStubs.php
@@ -9,7 +9,7 @@ use Composer\Script\Event;
 
 class FixWpStubs
 {
-	const STUBSFILE = '/giacocorsiglia/wordpress-stubs/wordpress-stubs.php';
+	const STUBSFILE = '/php-stubs/wordpress-stubs/wordpress-stubs.php';
 
 	public static function php73Polyfill(Event $event): int
 	{


### PR DESCRIPTION
Current Results:

```
Generating autoload files
> PHPStan\WordPress\Composer\FixWpStubs::php73Polyfill
Removing duplicate is_countable() ...
Script PHPStan\WordPress\Composer\FixWpStubs::php73Polyfill handling the post-update-cmd event terminated with an exception


  [ErrorException]
  file_get_contents(/Users/danpock/sites/wptest/vendor/giacocorsiglia/wordpress-stubs/wordpress-stubs.php): failed to open stream: No such file or
   directory
```

This file would be expected if the repo were using `giacocorsiglia`, however it's currently using from `php-stubs`.