### PR TITLE
Add WP-CLI early terminating calls

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -43,5 +43,3 @@ parameters:
         \WP_CLI:
             - WP_CLI::error
             - WP_CLI::halt
-            - WP_CLI::launch
-            - WP_CLI::runcommand

--- a/extension.neon
+++ b/extension.neon
@@ -39,3 +39,9 @@ parameters:
         - wp_send_json_error
         - wp_nonce_ays
         - dead_db
+    earlyTerminatingMethodCalls:
+        \WP_CLI:
+            - WP_CLI::error
+            - WP_CLI::halt
+            - WP_CLI::launch
+            - WP_CLI::runcommand


### PR DESCRIPTION
The ones that have `exit()` calls in them.

Fixes #22 

I'm not sure if the functions from the [utils.php](https://github.com/wp-cli/wp-cli/blob/master/php/utils.php) be included as well. Those are utility functions, not sure if they are used in userland code, or just for internal WP-CLI purposes.