### PR TITLE
Add support to `\wpdb::__get` magic method

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -4,6 +4,10 @@ services:
         tags:
             - phpstan.typeSpecifier.functionTypeSpecifyingExtension
     -
+        class: PHPStan\WordPress\wpdbMagicPropertiesClassReflectionExtension
+        tags:
+            - phpstan.broker.propertiesClassReflectionExtension
+    -
         class: PHPStan\WordPress\WpThemeMagicPropertiesClassReflectionExtension
         tags:
             - phpstan.broker.propertiesClassReflectionExtension

--- a/src/wpdbMagicPropertiesClassReflectionExtension.php
+++ b/src/wpdbMagicPropertiesClassReflectionExtension.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Accept magic properties of wpdb.
+ */
+
+declare(strict_types=1);
+
+namespace PHPStan\WordPress;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Reflection\Dummy\DummyPropertyReflection;
+
+class wpdbMagicPropertiesClassReflectionExtension implements \PHPStan\Reflection\PropertiesClassReflectionExtension
+{
+	/** @var array<int, string> */
+	private $properties = [ // phpcs:ignore SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+	                        'result',
+	                        'col_meta',
+	                        'table_charset',
+	                        'check_current_query',
+	                        'checking_collation',
+	                        'col_info',
+	                        'reconnect_retries',
+	                        'dbuser',
+	                        'dbpassword',
+	                        'dbname',
+	                        'dbhost',
+	                        'dbh',
+	                        'incompatible_modes',
+	                        'use_mysqli',
+	                        'has_connected',
+	];
+
+	public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+	{
+		if ($classReflection->getName() !== 'wpdb') {
+			return false;
+		}
+		return in_array($propertyName, $this->properties, true);
+	}
+
+	// phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+	public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+	{
+		return new DummyPropertyReflection();
+	}
+}


### PR DESCRIPTION
PHPStan would show an error when accessing properties such as `$wpdb->dbname` as they are protected properties.

However, `\wpdb` implements `__get`, which means these properties are accessible.