### PR TITLE
Set return type of wp_slash() and wp_unslash().

### DIFF
--- a/src/EscSqlDynamicFunctionReturnTypeExtension.php
+++ b/src/EscSqlDynamicFunctionReturnTypeExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Set return type of esc_sql().
+ * Set return type of esc_sql(), wp_slash() and wp_unslash().
  */
 
 declare(strict_types=1);
@@ -20,7 +20,7 @@ class EscSqlDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicF
 {
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
-        return $functionReflection->getName() === 'esc_sql';
+        return in_array($functionReflection->getName(), ['esc_sql', 'wp_slash', 'wp_unslash'], true);
     }
 
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type

--- a/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
+++ b/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
@@ -16,7 +16,7 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Type;
 
-class EscSqlDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+class StringOrArrayDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {


### PR DESCRIPTION
As `esc_sql()`, `wp_slash()` and `wp_unslash()` returns  `string|array`, but always the same type of the passed parameter.