### PR TITLE
Fix wrong class name in extension.neon

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -12,7 +12,7 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
-        class: PHPStan\WordPress\EscSqlDynamicFunctionReturnTypeExtension
+        class: PHPStan\WordPress\StringOrArrayDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -


### PR DESCRIPTION
This PR fixes the error:
`Service '0255': Class PHPStan\WordPress\EscSqlDynamicFunctionReturnTypeExtension not found. `
introduced in #34. When renaming the class name from `EscSqlDynamicFunctionReturnTypeExtension` to `StringOrArrayDynamicFunctionReturnTypeExtension`, I forgot to update the config file.

