### PR TITLE
Add dynamic return type extension for shortcode_atts

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -31,6 +31,10 @@ services:
         class: PHPStan\WordPress\GetCommentDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
+        class: PHPStan\WordPress\ShortcodeAttsDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
 parameters:
     bootstrapFiles:
         - ../../php-stubs/wordpress-stubs/wordpress-stubs.php

--- a/src/ShortcodeAttsDynamicFunctionReturnTypeExtension.php
+++ b/src/ShortcodeAttsDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Set return type of shortcode_atts().
+ */
+
+declare(strict_types=1);
+
+namespace PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Type;
+
+final class ShortcodeAttsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'shortcode_atts';
+    }
+
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        $argsCount = count($functionCall->args);
+        if ($argsCount === 0) {
+            return ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $functionCall->args,
+                $functionReflection->getVariants()
+            )->getReturnType();
+        }
+
+        return $scope->getType($functionCall->args[0]->value);
+    }
+}

--- a/src/ShortcodeAttsDynamicFunctionReturnTypeExtension.php
+++ b/src/ShortcodeAttsDynamicFunctionReturnTypeExtension.php
@@ -23,8 +23,7 @@ final class ShortcodeAttsDynamicFunctionReturnTypeExtension implements \PHPStan\
 
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
-        $argsCount = count($functionCall->args);
-        if ($argsCount === 0) {
+        if ($functionCall->args === []) {
             return ParametersAcceptorSelector::selectFromArgs(
                 $scope,
                 $functionCall->args,


### PR DESCRIPTION
See https://developer.wordpress.org/reference/functions/shortcode_atts/

I had a case where I strictly specified a list of supported shortcode args and used `shortcode_atts` to filter what is "coming in" which PHPStan did not understand. Something like the following but more dynamic in a function
```php

/** @var array{foo: string, baz: ?string} */
$supportedArgs = [
    'foo' => 'bar',
    'baz' => null,
];
$args = shortcode_atts($supportedArgs, $userArgs);
// $args is still array{foo: string, baz: ?string} here independent of what keys are existing in $userArgs

```