### PR TITLE
Fix WP_Nav_Menu_Args

### DIFF
--- a/example/class-wp-nav-menu-args.php
+++ b/example/class-wp-nav-menu-args.php
@@ -57,6 +57,13 @@ class WP_Nav_Menu_Args {
 	public $container_id;
 
 	/**
+	 * The aria-label attribute that is applied to the container when it's a nav element.
+	 *
+	 * @var string
+	 */
+	public $container_aria_label;
+
+	/**
 	 * If the menu doesn't exists, a callback function will fire.
 	 * Default is 'wp_page_menu'. Set to false for no fallback.
 	 *


### PR DESCRIPTION
Adds the `container_aria_label` argument which was added in WP 5.5.0.