### PR TITLE
Correct the default return type of `get_posts()`

### DIFF
--- a/src/GetPostsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostsDynamicFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ namespace PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
@@ -60,11 +59,7 @@ class GetPostsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
 
         // Without constant argument return default return type
         if (! isset($fields)) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $functionCall->args,
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));
         }
 
         switch ($fields) {


### PR DESCRIPTION
When `get_posts()` is called and the `fields` argument is not included, the return type is `array<int,WP_Post>`.