### PR TITLE
Correct the return type of `get_taxonomies()` when `$output` is not a string

### DIFF
--- a/src/GetTaxonomiesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTaxonomiesDynamicFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ namespace PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
@@ -40,11 +39,7 @@ class GetTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\D
 
         // When called with a non-string $output, return default return type
         if (! $argumentType instanceof ConstantStringType) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $functionCall->args,
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return new ArrayType(new IntegerType(), new ObjectType('WP_Taxonomy'));
         }
 
         // Called with a string $output


### PR DESCRIPTION
The return type of `get_taxonomies()` is `array<int,string>` when the `$output` parameter is exactly `names` and `array<int,WP_Taxonomy>` in all other cases.

Ref: https://github.com/WordPress/wordpress-develop/blob/afee26086fea307c2a5c31c0e2018cb6acd598f7/src/wp-includes/taxonomy.php#L215