### PR TITLE
Add a return type extension for `WP_Query->query()` and `WP_Query->get_posts()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -24,6 +24,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: PHPStan\WordPress\WPQueryDynamicMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
+    -
         class: PHPStan\WordPress\GetTaxonomiesDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/WPQueryDynamicMethodReturnTypeExtension.php
+++ b/src/WPQueryDynamicMethodReturnTypeExtension.php
@@ -72,10 +72,9 @@ class WPQueryDynamicMethodReturnTypeExtension implements \PHPStan\Type\DynamicMe
         }
 
         switch ($fields) {
+            case 'id=>parent':
             case 'ids':
                 return new ArrayType(new IntegerType(), new IntegerType());
-            case 'id=>parent':
-                return new ArrayType(new IntegerType(), new ObjectType('stdClass'));
             case 'all':
             default:
                 return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));

--- a/src/WPQueryDynamicMethodReturnTypeExtension.php
+++ b/src/WPQueryDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Set return type of various WP_Query methods.
+ */
+
+declare(strict_types=1);
+
+namespace PHPStan\WordPress;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Type;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+
+class WPQueryDynamicMethodReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
+{
+
+    public function getClass(): string
+    {
+        return 'WP_Query';
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return in_array($methodReflection->getName(), [
+            'get_posts',
+            'query',
+        ], true);
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/classes/wp_query/#return-fields-parameter
+     */
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+    {
+        // Called without arguments
+        if (count($methodCall->args) === 0) {
+            return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));
+        }
+
+        $argumentType = $scope->getType($methodCall->args[0]->value);
+
+        // Called with an array argument
+        if ($argumentType instanceof ConstantArrayType) {
+            foreach ($argumentType->getKeyTypes() as $index => $key) {
+                if (! $key instanceof ConstantStringType || $key->getValue() !== 'fields') {
+                    continue;
+                }
+
+                $fieldsType = $argumentType->getValueTypes()[$index];
+                if ($fieldsType instanceof ConstantStringType) {
+                    $fields = $fieldsType->getValue();
+                }
+                break;
+            }
+        }
+        // Called with a string argument
+        if ($argumentType instanceof ConstantStringType) {
+            parse_str($argumentType->getValue(), $variables);
+            $fields = $variables['fields'] ?? 'all';
+        }
+
+        // Without constant argument return default return type
+        if (! isset($fields)) {
+            return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));
+        }
+
+        switch ($fields) {
+            case 'ids':
+                return new ArrayType(new IntegerType(), new IntegerType());
+            case 'id=>parent':
+                return new ArrayType(new IntegerType(), new ObjectType('stdClass'));
+            case 'all':
+            default:
+                return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));
+        }
+    }
+}


### PR DESCRIPTION
Return type extension for `WP_Query->query()` and `WP_Query->get_posts()`.

As `get_posts()` ultimately calls `WP_Query->query()` and `WP_Query->get_posts()`, they all share the same return type pattern. Not sure if you want to combine them somehow.