### PR TITLE
Correct the return type for `get_posts()` with `id=>parent`

### DIFF
--- a/src/GetPostsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostsDynamicFunctionReturnTypeExtension.php
@@ -63,10 +63,9 @@ class GetPostsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
         }
 
         switch ($fields) {
+            case 'id=>parent':
             case 'ids':
                 return new ArrayType(new IntegerType(), new IntegerType());
-            case 'id=>parent':
-                return new ArrayType(new IntegerType(), new ObjectType('stdClass'));
             case 'all':
             default:
                 return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));


### PR DESCRIPTION
Using `id=>parent` returns `array<int,int>`, not `array<int,stdClass>`.

Refs:

* https://github.com/johnbillion/wordpress-develop/blob/b6046636f015f6e1fac6b565f883fa9679b90a72/src/wp-includes/class-wp-query.php#L655-L656
* https://github.com/johnbillion/wordpress-develop/blob/b6046636f015f6e1fac6b565f883fa9679b90a72/src/wp-includes/class-wp-query.php#L2965-L2982