### PR TITLE
Add return type definitions for `get_terms()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -20,6 +20,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: SzepeViktor\PHPStan\WordPress\GetTermsDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\GetPostDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/GetTermsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTermsDynamicFunctionReturnTypeExtension.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace PHPStan\WordPress;
+namespace SzepeViktor\PHPStan\WordPress;
 
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;

--- a/src/GetTermsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTermsDynamicFunctionReturnTypeExtension.php
@@ -42,6 +42,7 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
         $fields = 'all';
         $arrayOfSlugs = new ArrayType(new IntegerType(), new StringType());
         $arrayOfIds = new ArrayType(new IntegerType(), new IntegerType());
+        $arrayOfParents = new ArrayType(new IntegerType(), new StringType());
         $arrayOfTerms = new ArrayType(new IntegerType(), new ObjectType('WP_Term'));
         $count = new StringType();
         $error = new ObjectType('WP_Error');
@@ -100,9 +101,13 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
                 );
             case 'ids':
             case 'tt_ids':
-            case 'id=>parent':
                 return TypeCombinator::union(
                     $arrayOfIds,
+                    $error
+                );
+            case 'id=>parent':
+                return TypeCombinator::union(
+                    $arrayOfParents,
                     $error
                 );
             case 'all':

--- a/src/GetTermsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTermsDynamicFunctionReturnTypeExtension.php
@@ -181,7 +181,7 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
             self::termsType(),
             self::idsType(),
             self::slugsType(),
-            self::countType(),
+            self::countType()
         );
     }
 }

--- a/src/GetTermsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTermsDynamicFunctionReturnTypeExtension.php
@@ -21,7 +21,6 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ConstantScalarType;
-use PHPStan\Type\ConstantType;
 use PHPStan\Type\TypeCombinator;
 
 class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
@@ -99,7 +98,7 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
             );
         }
 
-        if (! isset($args['fields'])) {
+        if (! isset($args['fields'], $args['count'])) {
             return TypeCombinator::union(
                 $termsType,
                 $idsType,

--- a/src/GetTermsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTermsDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Set return type of get_terms() and related functions.
+ */
+
+declare(strict_types=1);
+
+namespace PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Type;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+
+class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return in_array($functionReflection->getName(), [
+            'get_tags',
+            'get_terms',
+            'wp_get_object_terms',
+        ], true);
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/classes/wp_term_query/__construct/
+     */
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        // Called without arguments
+        if (count($functionCall->args) === 0) {
+            return new ArrayType(new IntegerType(), new ObjectType('WP_Term'));
+        }
+
+        $argumentType = $scope->getType($functionCall->args[0]->value);
+
+        // Called with an array argument
+        if ($argumentType instanceof ConstantArrayType) {
+            foreach ($argumentType->getKeyTypes() as $index => $key) {
+                if (! $key instanceof ConstantStringType || $key->getValue() !== 'fields') {
+                    continue;
+                }
+
+                $fieldsType = $argumentType->getValueTypes()[$index];
+                if ($fieldsType instanceof ConstantStringType) {
+                    $fields = $fieldsType->getValue();
+                }
+                break;
+            }
+        }
+        // Called with a string argument
+        if ($argumentType instanceof ConstantStringType) {
+            parse_str($argumentType->getValue(), $variables);
+            $fields = $variables['fields'] ?? 'all';
+        }
+
+        // Without constant argument return default return type
+        if (! isset($fields)) {
+            return new ArrayType(new IntegerType(), new ObjectType('WP_Term'));
+        }
+
+        switch ($fields) {
+            case 'count':
+                return new IntegerType();
+            case 'names':
+            case 'slugs':
+            case 'id=>name':
+            case 'id=>slug':
+                return new ArrayType(new IntegerType(), new StringType());
+            case 'ids':
+            case 'tt_ids':
+            case 'id=>parent':
+                return new ArrayType(new IntegerType(), new IntegerType());
+            case 'all':
+            case 'all_with_object_id':
+            default:
+                return new ArrayType(new IntegerType(), new ObjectType('WP_Term'));
+        }
+    }
+}

--- a/src/GetTermsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTermsDynamicFunctionReturnTypeExtension.php
@@ -39,19 +39,19 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
      */
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
-        $fields = 'all';
-        $arrayOfSlugs = new ArrayType(new IntegerType(), new StringType());
-        $arrayOfIds = new ArrayType(new IntegerType(), new IntegerType());
-        $arrayOfParents = new ArrayType(new IntegerType(), new StringType());
-        $arrayOfTerms = new ArrayType(new IntegerType(), new ObjectType('WP_Term'));
-        $count = new StringType();
-        $error = new ObjectType('WP_Error');
+        $fieldsValue = 'all';
+        $slugsType = new ArrayType(new IntegerType(), new StringType());
+        $idsType = new ArrayType(new IntegerType(), new IntegerType());
+        $parentsType = new ArrayType(new IntegerType(), new StringType());
+        $termsType = new ArrayType(new IntegerType(), new ObjectType('WP_Term'));
+        $countType = new StringType();
+        $errorType = new ObjectType('WP_Error');
 
         // Called without arguments
         if (count($functionCall->args) === 0) {
             return TypeCombinator::union(
-                $arrayOfTerms,
-                $error
+                $termsType,
+                $errorType
             );
         }
 
@@ -66,14 +66,14 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
 
                 $fieldsType = $argumentType->getValueTypes()[$index];
                 if ($fieldsType instanceof ConstantStringType) {
-                    $fields = $fieldsType->getValue();
+                    $fieldsValue = $fieldsType->getValue();
                 } else {
                     return TypeCombinator::union(
-                        $arrayOfTerms,
-                        $arrayOfIds,
-                        $arrayOfSlugs,
-                        $count,
-                        $error
+                        $termsType,
+                        $idsType,
+                        $slugsType,
+                        $countType,
+                        $errorType
                     );
                 }
                 break;
@@ -81,49 +81,49 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
         } elseif ($argumentType instanceof ConstantStringType) {
             // Called with a string argument
             parse_str($argumentType->getValue(), $variables);
-            $fields = $variables['fields'] ?? 'all';
+            $fieldsValue = $variables['fields'] ?? 'all';
         } else {
             // Without constant argument return default return type
             return TypeCombinator::union(
-                $arrayOfTerms,
-                $arrayOfIds,
-                $arrayOfSlugs,
-                $count,
-                $error
+                $termsType,
+                $idsType,
+                $slugsType,
+                $countType,
+                $errorType
             );
         }
 
-        switch ($fields) {
+        switch ($fieldsValue) {
             case 'count':
                 return TypeCombinator::union(
-                    $count,
-                    $error
+                    $countType,
+                    $errorType
                 );
             case 'names':
             case 'slugs':
             case 'id=>name':
             case 'id=>slug':
                 return TypeCombinator::union(
-                    $arrayOfSlugs,
-                    $error
+                    $slugsType,
+                    $errorType
                 );
             case 'ids':
             case 'tt_ids':
                 return TypeCombinator::union(
-                    $arrayOfIds,
-                    $error
+                    $idsType,
+                    $errorType
                 );
             case 'id=>parent':
                 return TypeCombinator::union(
-                    $arrayOfParents,
-                    $error
+                    $parentsType,
+                    $errorType
                 );
             case 'all':
             case 'all_with_object_id':
             default:
                 return TypeCombinator::union(
-                    $arrayOfTerms,
-                    $error
+                    $termsType,
+                    $errorType
                 );
         }
     }

--- a/src/GetTermsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTermsDynamicFunctionReturnTypeExtension.php
@@ -67,6 +67,14 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
                 $fieldsType = $argumentType->getValueTypes()[$index];
                 if ($fieldsType instanceof ConstantStringType) {
                     $fields = $fieldsType->getValue();
+                } else {
+                    return TypeCombinator::union(
+                        $arrayOfTerms,
+                        $arrayOfIds,
+                        $arrayOfSlugs,
+                        $count,
+                        $error
+                    );
                 }
                 break;
             }

--- a/src/GetTermsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTermsDynamicFunctionReturnTypeExtension.php
@@ -78,10 +78,6 @@ class GetTermsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
                 }
                 break;
             }
-        } elseif ($argumentType instanceof ConstantStringType) {
-            // Called with a string argument
-            parse_str($argumentType->getValue(), $variables);
-            $fieldsValue = $variables['fields'] ?? 'all';
         } else {
             // Without constant argument return default return type
             return TypeCombinator::union(

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -18,6 +18,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_comment.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_terms.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -7,6 +7,7 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 use function PHPStan\Testing\assertType;
 
 $fields = $_GET['fields'] ?? 'all';
+$key = $_GET['key'] ?? 'fields';
 
 // Default argument values
 assertType('array<int, WP_Term>|WP_Error', get_terms());
@@ -16,6 +17,12 @@ assertType('array<int, WP_Term>|WP_Error', get_terms([]));
 assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms(['fields'=>$fields]));
 assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms(['foo'=>'bar','fields'=>$fields]));
 
+// Unknown keys
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$key=>'all']));
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['foo'=>'bar',$key=>'all']));
+
 // Requesting a count
 assertType('string|WP_Error', get_terms(['fields'=>'count']));
 assertType('string|WP_Error', get_terms(['foo'=>'bar','fields'=>'count']));
+assertType('string|WP_Error', get_terms(['count'=>true]));
+assertType('string|WP_Error', get_terms(['foo'=>'bar','count'=>true]));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -13,9 +13,9 @@ $key = $_GET['key'] ?? 'fields';
 assertType('array<int, WP_Term>|WP_Error', get_terms());
 assertType('array<int, WP_Term>|WP_Error', get_terms([]));
 
-// Unknown
-assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms(['fields'=>$fields]));
-assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms(['foo'=>'bar','fields'=>$fields]));
+// Unknown values
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$fields]));
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['foo'=>'bar','fields'=>$fields]));
 
 // Unknown keys
 assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$key=>'all']));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -9,6 +9,6 @@ use function PHPStan\Testing\assertType;
 $fields = $_GET['fields'] ?? 'all';
 
 // Default argument values
-assertType('array<int, WP_Term>', get_terms());
-assertType('array<int, WP_Term>', get_terms([]));
-assertType('array<int, WP_Term>', get_terms(''));
+assertType('array<int, WP_Term>|WP_Error', get_terms());
+assertType('array<int, WP_Term>|WP_Error', get_terms([]));
+assertType('array<int, WP_Term>|WP_Error', get_terms(''));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -8,6 +8,7 @@ use function PHPStan\Testing\assertType;
 
 $fields = $_GET['fields'] ?? 'all';
 $key = $_GET['key'] ?? 'fields';
+$count = ! empty( $_GET['count'] );
 
 // Default argument values
 assertType('array<int, WP_Term>|WP_Error', get_terms());
@@ -16,6 +17,9 @@ assertType('array<int, WP_Term>|WP_Error', get_terms([]));
 // Unknown values
 assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$fields]));
 assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['foo'=>'bar','fields'=>$fields]));
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['count'=>$count]));
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['count'=>$count,'fields'=>'ids']));
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$fields,'count'=>false]));
 
 // Unknown keys
 assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$key=>'all']));
@@ -27,6 +31,7 @@ assertType('string|WP_Error', get_terms(['foo'=>'bar','fields'=>'count']));
 assertType('string|WP_Error', get_terms(['count'=>true]));
 assertType('string|WP_Error', get_terms(['foo'=>'bar','count'=>true]));
 assertType('string|WP_Error', get_terms(['fields'=>'ids','count'=>true]));
+assertType('string|WP_Error', get_terms(['fields'=>$fields,'count'=>true]));
 
 // Requesting names or slugs
 assertType('array<int, string>|WP_Error', get_terms(['fields'=>'names']));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function PHPStan\Testing\assertType;
+
+$fields = $_GET['fields'] ?? 'all';
+
+// Default argument values
+assertType('array<int, WP_Term>', get_terms());
+assertType('array<int, WP_Term>', get_terms([]));
+assertType('array<int, WP_Term>', get_terms(''));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -50,3 +50,13 @@ assertType('array<int, string>|WP_Error', get_terms(['fields'=>'id=>parent']));
 assertType('array<int, WP_Term>|WP_Error', get_terms(['fields'=>'all']));
 assertType('array<int, WP_Term>|WP_Error', get_terms(['fields'=>'all_with_object_id']));
 assertType('array<int, WP_Term>|WP_Error', get_terms(['fields'=>'foo']));
+
+// Wrapper functions
+assertType('string|WP_Error', wp_get_object_terms(123, 'category', ['fields'=>'count']));
+assertType('string|WP_Error', wp_get_post_categories(123, ['fields'=>'count']));
+assertType('string|WP_Error', wp_get_post_tags(123, ['fields'=>'count']));
+assertType('string|WP_Error', wp_get_post_terms(123, 'category', ['fields'=>'count']));
+assertType('array<int, WP_Term>|WP_Error', wp_get_object_terms(123, 'category'));
+assertType('array<int, WP_Term>|WP_Error', wp_get_post_categories(123));
+assertType('array<int, WP_Term>|WP_Error', wp_get_post_tags(123));
+assertType('array<int, WP_Term>|WP_Error', wp_get_post_terms(123, 'category'));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -13,6 +13,11 @@ assertType('array<int, WP_Term>|WP_Error', get_terms());
 assertType('array<int, WP_Term>|WP_Error', get_terms([]));
 assertType('array<int, WP_Term>|WP_Error', get_terms(''));
 
+// Unknown
+assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms(['fields'=>$fields]));
+assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms(['foo'=>'bar','fields'=>$fields]));
+assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms("fields={$fields}"));
+
 // Requesting a count
 assertType('string|WP_Error', get_terms(['fields'=>'count']));
 assertType('string|WP_Error', get_terms(['foo'=>'bar','fields'=>'count']));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -12,3 +12,8 @@ $fields = $_GET['fields'] ?? 'all';
 assertType('array<int, WP_Term>|WP_Error', get_terms());
 assertType('array<int, WP_Term>|WP_Error', get_terms([]));
 assertType('array<int, WP_Term>|WP_Error', get_terms(''));
+
+// Requesting a count
+assertType('string|WP_Error', get_terms(['fields'=>'count']));
+assertType('string|WP_Error', get_terms(['foo'=>'bar','fields'=>'count']));
+assertType('string|WP_Error', get_terms('fields=count'));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -26,3 +26,23 @@ assertType('string|WP_Error', get_terms(['fields'=>'count']));
 assertType('string|WP_Error', get_terms(['foo'=>'bar','fields'=>'count']));
 assertType('string|WP_Error', get_terms(['count'=>true]));
 assertType('string|WP_Error', get_terms(['foo'=>'bar','count'=>true]));
+assertType('string|WP_Error', get_terms(['fields'=>'ids','count'=>true]));
+
+// Requesting names or slugs
+assertType('array<int, string>|WP_Error', get_terms(['fields'=>'names']));
+assertType('array<int, string>|WP_Error', get_terms(['fields'=>'slugs']));
+assertType('array<int, string>|WP_Error', get_terms(['fields'=>'id=>name']));
+assertType('array<int, string>|WP_Error', get_terms(['fields'=>'id=>slug']));
+
+// Requesting IDs
+assertType('array<int, int>|WP_Error', get_terms(['fields'=>'ids']));
+assertType('array<int, int>|WP_Error', get_terms(['fields'=>'tt_ids']));
+
+// Requesting parent IDs (numeric strings)
+assertType('array<int, string>|WP_Error', get_terms(['fields'=>'names']));
+assertType('array<int, string>|WP_Error', get_terms(['fields'=>'slugs']));
+
+// Requesting objects
+assertType('array<int, WP_Term>|WP_Error', get_terms(['fields'=>'all']));
+assertType('array<int, WP_Term>|WP_Error', get_terms(['fields'=>'all_with_object_id']));
+assertType('array<int, WP_Term>|WP_Error', get_terms(['fields'=>'foo']));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -39,8 +39,7 @@ assertType('array<int, int>|WP_Error', get_terms(['fields'=>'ids']));
 assertType('array<int, int>|WP_Error', get_terms(['fields'=>'tt_ids']));
 
 // Requesting parent IDs (numeric strings)
-assertType('array<int, string>|WP_Error', get_terms(['fields'=>'names']));
-assertType('array<int, string>|WP_Error', get_terms(['fields'=>'slugs']));
+assertType('array<int, string>|WP_Error', get_terms(['fields'=>'id=>parent']));
 
 // Requesting objects
 assertType('array<int, WP_Term>|WP_Error', get_terms(['fields'=>'all']));

--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -11,14 +11,11 @@ $fields = $_GET['fields'] ?? 'all';
 // Default argument values
 assertType('array<int, WP_Term>|WP_Error', get_terms());
 assertType('array<int, WP_Term>|WP_Error', get_terms([]));
-assertType('array<int, WP_Term>|WP_Error', get_terms(''));
 
 // Unknown
 assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms(['fields'=>$fields]));
 assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms(['foo'=>'bar','fields'=>$fields]));
-assertType('array<int, WP_Term>|array<int, int>|array<int, string>|string|WP_Error', get_terms("fields={$fields}"));
 
 // Requesting a count
 assertType('string|WP_Error', get_terms(['fields'=>'count']));
 assertType('string|WP_Error', get_terms(['foo'=>'bar','fields'=>'count']));
-assertType('string|WP_Error', get_terms('fields=count'));


### PR DESCRIPTION
Introduces a dynamic return type extension for `get_terms()` and its wrapper functions. The `fields` and `count` arguments determine the return types.

Todo:

* `fields` argument set to:
  - [x] Indeterminate value
  - [x] `count`
  - [x] `names`/`slugs`/`id=>name`/`id=>slug`
  - [x] `ids`/`tt_ids`
  - [x] `id=>parent`
  - [x] `all`
  - [x] `all_with_object_id`
  - [x] Default / empty args
* `count` argument set to:
  - [x] Indeterminate value
  - [x] `true`
* [x] Final round of testing WP core's actual return types of `get_terms()`
* [x] Coding standards
* [x] DRY
* Confirm this definitely applies to:
  - [x] `get_tags()`
  - [x] `get_terms()`
  - [x] `wp_get_object_terms()`
  - [x] Any others?