### PR TITLE
Add a dynamic return type extension for `get_object_taxonomies()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -28,6 +28,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: SzepeViktor\PHPStan\WordPress\GetObjectTaxonomiesDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\GetCommentDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Set return type of get_object_taxonomies().
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Type;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Constant\ConstantStringType;
+
+class GetObjectTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return in_array($functionReflection->getName(), ['get_object_taxonomies'], true);
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/functions/get_object_taxonomies/
+     */
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        // Called without second $output argument
+        if (count($functionCall->args) <= 1) {
+            return new ArrayType(new IntegerType(), new StringType());
+        }
+
+        $argumentType = $scope->getType($functionCall->args[1]->value);
+
+        // When called with a non-string $output, return default return type
+        if (! $argumentType instanceof ConstantStringType) {
+			return new ArrayType(new IntegerType(), new StringType());
+        }
+
+        // Called with a string $output
+        switch ($argumentType->getValue()) {
+            case 'objects':
+                return new ArrayType(new StringType(), new ObjectType('WP_Taxonomy'));
+            case 'names':
+            default:
+                return new ArrayType(new IntegerType(), new StringType());
+        }
+    }
+}

--- a/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+// phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+
 /**
  * Set return type of get_object_taxonomies().
  */
@@ -27,8 +29,6 @@ class GetObjectTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\
 
     /**
      * @see https://developer.wordpress.org/reference/functions/get_object_taxonomies/
-     *
-     * phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
      */
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {

--- a/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
@@ -27,6 +27,8 @@ class GetObjectTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\
 
     /**
      * @see https://developer.wordpress.org/reference/functions/get_object_taxonomies/
+     *
+     * phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
      */
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {

--- a/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
@@ -39,7 +39,7 @@ class GetObjectTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\
 
         // When called with a non-string $output, return default return type
         if (! $argumentType instanceof ConstantStringType) {
-			return new ArrayType(new IntegerType(), new StringType());
+            return new ArrayType(new IntegerType(), new StringType());
         }
 
         // Called with a string $output


### PR DESCRIPTION
`get_object_taxonomies()` function returns:

* `array<string,WP_Taxonomy>` when `$output` is `'objects'`
* `array<int,string>` otherwise