### PR TITLE
Add a return type extension for `mysql2date()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -35,6 +35,10 @@ services:
         class: SzepeViktor\PHPStan\WordPress\ShortcodeAttsDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
+        class: SzepeViktor\PHPStan\WordPress\MySQL2DateDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
 parameters:
     bootstrapFiles:
         - ../../php-stubs/wordpress-stubs/wordpress-stubs.php

--- a/src/MySQL2DateDynamicFunctionReturnTypeExtension.php
+++ b/src/MySQL2DateDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Set return type of mysql2date().
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Type;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
+
+class MySQL2DateDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return in_array($functionReflection->getName(), ['mysql2date'], true);
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/functions/mysql2date/
+     */
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        $argumentType = $scope->getType($functionCall->args[0]->value);
+
+        // When called with a non-string $format, return default return type
+        if (! $argumentType instanceof ConstantStringType) {
+            return ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $functionCall->args,
+                $functionReflection->getVariants()
+            )->getReturnType();
+        }
+
+        // Called with a string $format
+        switch ($argumentType->getValue()) {
+            case 'G':
+            case 'U':
+                return new UnionType([new ConstantBooleanType(false), new IntegerType()]);
+            default:
+                return new UnionType([new ConstantBooleanType(false), new StringType()]);
+        }
+    }
+}


### PR DESCRIPTION
`mysql2date()` function returns:

* `false|int` when `$format` is `'G'` or `'U'`
* `false|string` otherwise