### PR TITLE
Switch to PHPStan v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "nikic/php-parser": "< 4.13.0",
         "php-parallel-lint/php-parallel-lint": "^1.1",
-        "phpstan/phpstan-strict-rules": "^1",
+        "phpstan/phpstan-strict-rules": "^1.0",
         "phpunit/phpunit": "^7 || ^9",
         "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "php-stubs/wordpress-stubs": "^4.7 || ^5.0",
-        "phpstan/phpstan": "^0.12.26",
+        "phpstan/phpstan": "^1",
         "symfony/polyfill-php73": "^1.12.0"
     },
     "require-dev": {
@@ -21,7 +21,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
         "nikic/php-parser": "< 4.13.0",
         "php-parallel-lint/php-parallel-lint": "^1.1",
-        "phpstan/phpstan-strict-rules": "^0.12",
+        "phpstan/phpstan-strict-rules": "^1",
         "phpunit/phpunit": "^7 || ^9",
         "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.6"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "php-stubs/wordpress-stubs": "^4.7 || ^5.0",
-        "phpstan/phpstan": "^1",
+        "phpstan/phpstan": "^1.0",
         "symfony/polyfill-php73": "^1.12.0"
     },
     "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
     - vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon
 parameters:
-    level: max
+    level: 8
     # WpThemeMagicPropertiesClassReflectionExtension needs WP_Theme
     scanFiles:
         - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php


### PR DESCRIPTION
I've fixed the level to 8 because max uses the new level 9 which results in some errors with `mixed` which can be addressed at a later date.