### PR TITLE
`apply_filters()` return type

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -51,6 +51,10 @@ services:
         class: SzepeViktor\PHPStan\WordPress\CurrentTimeDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
+        class: SzepeViktor\PHPStan\WordPress\ApplyFiltersDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
 parameters:
     bootstrapFiles:
         - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,5 @@
 <phpunit
+	bootstrap="tests/bootstrap.php"
 	colors="true"
 	failOnRisky="true"
 	failOnWarning="true"

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Set return type of apply_filters().
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDoc\PhpDocStringResolver;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Type;
+use PHPStan\Type\MixedType;
+
+class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return in_array(
+            $functionReflection->getName(),
+            [
+                'apply_filters',
+            ],
+            true
+        );
+    }
+
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        $default = new MixedType();
+
+        /** @var \PhpParser\Node\Expr\Assign|null */
+        $parent = $functionCall->getAttribute( 'parent' );
+
+        if (null === $parent) {
+            return $default;
+        }
+
+        // Fetch the docblock from the parent.
+        $comment = $parent->getDocComment();
+
+        if (null === $comment) {
+            return $default;
+        }
+
+        // Fetch the docblock contents and resolve it to a PhpDocNode.
+        $code = $comment->getText();
+        $docResolver = new PhpDocStringResolver( new Lexer(), new PhpDocParser( new TypeParser(), new ConstExprParser() ) );
+        $doc = $docResolver->resolve($code);
+
+        // Fetch the `@param` values from the docblock.
+        $params = $doc->getParamTagValues();
+
+        if (! $params) {
+            return $default;
+        }
+
+        // Fetch the `@param` types as a TypeNode.
+        $type = $params[0]->type;
+
+        // @TODO Fetch and return the Type that corresponds to the TypeNode.
+
+        return $default;
+    }
+}

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -17,7 +17,10 @@ use PHPStan\Type\MixedType;
 
 class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
-    protected FileTypeMapper $fileTypeMapper;
+    /**
+     * @var FileTypeMapper
+     */
+    protected $fileTypeMapper;
 
     public function __construct(
         FileTypeMapper $fileTypeMapper

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -11,6 +11,7 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDoc\PhpDocStringResolver;
+use PHPStan\PhpDoc\TypeNodeResolver;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
@@ -21,6 +22,18 @@ use PHPStan\Type\MixedType;
 
 class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
+    protected PhpDocStringResolver $phpDocStringResolver;
+    protected TypeNodeResolver $typeNodeResolver;
+
+    public function __construct(
+        PhpDocStringResolver $phpDocStringResolver,
+        TypeNodeResolver $typeNodeResolver
+    )
+    {
+        $this->phpDocStringResolver = $phpDocStringResolver;
+        $this->typeNodeResolver = $typeNodeResolver;
+    }
+
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
         return in_array(
@@ -53,8 +66,7 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
 
         // Fetch the docblock contents and resolve it to a PhpDocNode.
         $code = $comment->getText();
-        $docResolver = new PhpDocStringResolver( new Lexer(), new PhpDocParser( new TypeParser(), new ConstExprParser() ) );
-        $doc = $docResolver->resolve($code);
+        $doc = $this->phpDocStringResolver->resolve($code);
 
         // Fetch the `@param` values from the docblock.
         $params = $doc->getParamTagValues();

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -17,14 +17,11 @@ use PHPStan\Type\MixedType;
 
 class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
-    /**
-     * @var FileTypeMapper
-     */
+    /** @var \PHPStan\Type\FileTypeMapper */
     protected $fileTypeMapper;
 
-    public function __construct(
-        FileTypeMapper $fileTypeMapper
-    ) {
+    public function __construct(FileTypeMapper $fileTypeMapper)
+    {
         $this->fileTypeMapper = $fileTypeMapper;
     }
 

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -63,15 +63,18 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
         // Fetch the `@param` values from the docblock.
         $params = $doc->getParamTagValues();
 
-        if (! $params) {
+        if (count($params) === 0) {
             return $default;
         }
+
+        $classReflection = $scope->getClassReflection();
+        $traitReflection = $scope->getTraitReflection();
 
         // Need to resolve the docblock in scope in order to get a NameScope object.
         $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
             $scope->getFile(),
-            $scope->isInClass() ? $scope->getClassReflection()->getName() : null,
-            $scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
+            ($scope->isInTrait() && $traitReflection !== null) ? $traitReflection->getName() : null,
+            ($scope->isInClass() && $classReflection !== null) ? $classReflection->getName() : null,
             $scope->getFunctionName(),
             $code
         );
@@ -86,7 +89,7 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
         return $this->typeNodeResolver->resolve($params[0]->type, $nameScope);
     }
 
-    private static function getNullableNodeComment(\PhpParser\Node $node): ?\PhpParser\Comment\Doc
+    private static function getNullableNodeComment(FuncCall $node): ?\PhpParser\Comment\Doc
     {
         $startLine = $node->getStartLine();
 

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -60,7 +60,19 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
         $comment = $parent->getDocComment();
 
         if ($comment === null) {
-            return $default;
+            /** @var \PhpParser\Node\Expr\Assign|null */
+            $grandparent = $parent->getAttribute('parent');
+
+            if ($grandparent === null) {
+                return $default;
+            }
+
+            // Fetch the docblock from the grandparent.
+            $comment = $grandparent->getDocComment();
+
+            if ($comment === null) {
+                return $default;
+            }
         }
 
         // Fetch the docblock contents and resolve it to a PhpDocNode.

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -39,6 +39,8 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
             $functionReflection->getName(),
             [
                 'apply_filters',
+                'apply_filters_deprecated',
+                'apply_filters_ref_array',
             ],
             true
         );

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -12,10 +12,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDoc\PhpDocStringResolver;
 use PHPStan\PhpDoc\TypeNodeResolver;
-use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
-use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TypeParser;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\Type;
@@ -31,8 +27,7 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
         FileTypeMapper $fileTypeMapper,
         PhpDocStringResolver $phpDocStringResolver,
         TypeNodeResolver $typeNodeResolver
-    )
-    {
+    ) {
         $this->fileTypeMapper = $fileTypeMapper;
         $this->phpDocStringResolver = $phpDocStringResolver;
         $this->typeNodeResolver = $typeNodeResolver;
@@ -55,16 +50,16 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
         $default = new MixedType();
 
         /** @var \PhpParser\Node\Expr\Assign|null */
-        $parent = $functionCall->getAttribute( 'parent' );
+        $parent = $functionCall->getAttribute('parent');
 
-        if (null === $parent) {
+        if ($parent === null) {
             return $default;
         }
 
         // Fetch the docblock from the parent.
         $comment = $parent->getDocComment();
 
-        if (null === $comment) {
+        if ($comment === null) {
             return $default;
         }
 
@@ -78,9 +73,6 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
         if (! $params) {
             return $default;
         }
-
-        // Fetch the `@param` types as a TypeNode.
-        $type = $params[0]->type;
 
         $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
             $scope->getFile(),
@@ -96,6 +88,6 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
             return $default;
         }
 
-        return $this->typeNodeResolver->resolve( $type, $nameScope );
+        return $this->typeNodeResolver->resolve($params[0]->type, $nameScope);
     }
 }

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Set return type of apply_filters().
+ * Set return type of apply_filters() based on its optional preceding docblock.
  */
 
 declare(strict_types=1);
@@ -84,7 +84,7 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
 
         $nameScope = $resolvedPhpDoc->getNullableNameScope();
 
-        if (! $nameScope) {
+        if (null === $nameScope) {
             return $default;
         }
 

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -73,8 +73,8 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
         // Need to resolve the docblock in scope in order to get a NameScope object.
         $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
             $scope->getFile(),
-            ($scope->isInTrait() && $traitReflection !== null) ? $traitReflection->getName() : null,
             ($scope->isInClass() && $classReflection !== null) ? $classReflection->getName() : null,
+            ($scope->isInTrait() && $traitReflection !== null) ? $traitReflection->getName() : null,
             $scope->getFunctionName(),
             $code
         );

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -96,7 +96,7 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
 
         $nameScope = $resolvedPhpDoc->getNullableNameScope();
 
-        if (null === $nameScope) {
+        if ($nameScope === null) {
             return $default;
         }
 

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -86,6 +86,7 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
             return $default;
         }
 
+        // Need to resolve the docblock again in order to get a NameScope object.
         $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
             $scope->getFile(),
             $scope->isInClass() ? $scope->getClassReflection()->getName() : null,
@@ -100,6 +101,7 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
             return $default;
         }
 
+        // Return the Type resolved from the TypeNode.
         return $this->typeNodeResolver->resolve($params[0]->type, $nameScope);
     }
 }

--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -88,12 +88,12 @@ class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
             return $default;
         }
 
-        // Need to resolve the docblock again in order to get a NameScope object.
+        // Need to resolve the docblock in scope in order to get a NameScope object.
         $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
             $scope->getFile(),
             $scope->isInClass() ? $scope->getClassReflection()->getName() : null,
             $scope->isInTrait() ? $scope->getTraitReflection()->getName() : null,
-            null,
+            $scope->getFunctionName(),
             $code
         );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
 error_reporting(E_ALL);
 
 require_once __DIR__ . '/../vendor/autoload.php';
+
+/**
+ * Returns the passed value.
+ *
+ * @template T
+ * @param T $value Value.
+ * @return T Value.
+ */
+function return_value( $value ) {
+    return $value;
+}

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -7,17 +7,6 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 use function apply_filters;
 use function PHPStan\Testing\assertType;
 
-/**
- * Returns the passed value.
- *
- * @template T
- * @param T $value Value.
- * @return T Value.
- */
-function return_value( $value ) {
-    return $value;
-}
-
 // This assertion is here because any value that passes through `return_value()`
 // has a type of `*ERROR*` and I don't know why. It works fine on the playground:
 // https://phpstan.org/r/d7b65195-af14-40cf-a216-9b70bdda21c0

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -18,6 +18,12 @@ function return_value( $value ) {
     return $value;
 }
 
+// This assertion is here because any value that passes through `return_value()`
+// has a type of `*ERROR*` and I don't know why. It works fine on the playground:
+// https://phpstan.org/r/d7b65195-af14-40cf-a216-9b70bdda21c0
+$value = return_value(123);
+assertType('int', $value);
+
 $value = apply_filters('filter','Hello, World');
 assertType('mixed', $value);
 

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -12,6 +12,16 @@ $value = apply_filters('filter','Hello, World');
 assertType('mixed', $value);
 
 /**
+ * Unknown parameter.
+ */
+$value = apply_filters('filter',$foo);
+assertType('mixed', $value);
+
+/** @var int $value */
+$value = apply_filters('filter',$foo);
+assertType('int', $value);
+
+/**
  * Single type.
  *
  * @param string $foo Hello, World.

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -85,3 +85,24 @@ assertType('array', $value);
  */
 $value = return_value(apply_filters('filter',$foo));
 assertType('string', $value);
+
+/**
+ * Filters the maximum image size dimensions for the editor.
+ *
+ * @since 2.5.0
+ *
+ * @param int[]        $max_image_size {
+ *     An array of width and height values.
+ *
+ *     @type int $0 The maximum width in pixels.
+ *     @type int $1 The maximum height in pixels.
+ * }
+ * @param string|int[] $size     Requested image size. Can be any registered image size name, or
+ *                               an array of width and height values in pixels (in that order).
+ * @param string       $context  The context the image is being resized for.
+ *                               Possible values are 'display' (like in a theme)
+ *                               or 'edit' (like inserting into an editor).
+ */
+list($max_width, $max_height) = apply_filters('editor_max_image_size', [$max_width, $max_height], $size, $context);
+assertType('int', $max_width);
+assertType('int', $max_height);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -6,7 +6,6 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 
 use function apply_filters;
 use function PHPStan\Testing\assertType;
-use stdClass;
 
 $value = apply_filters('filter','Hello, World');
 assertType('mixed', $value);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -155,3 +155,7 @@ assertType('int', $value);
 list($max_width, $max_height) = apply_filters('editor_max_image_size', [$max_width, $max_height], $size, $context);
 assertType('int', $max_width);
 assertType('int', $max_height);
+
+/** This filter is documented in foo.php */
+$value = apply_filters('foo', 123);
+assertType('mixed', $value);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -99,6 +99,42 @@ assertType('array', $value);
 $value = return_value(apply_filters('filter',$foo));
 assertType('string', $value);
 
+$value = return_value(
+    return_value(
+        return_value(
+            /**
+             * Multiple nested function calls.
+             *
+             * @param string $foo Hello, World.
+             */
+            apply_filters('filter',$foo)
+        )
+    )
+);
+assertType('string', $value);
+
+/**
+ * Incorrect docblock placement that should be ignored.
+ *
+ * @param string $foo Hello, World.
+ */
+$value = return_value(
+    return_value(
+        return_value(
+            apply_filters('filter',$foo)
+        )
+    )
+);
+assertType('mixed', $value);
+
+/**
+ * Casting to a type.
+ *
+ * @param float|int|null $foo Hello, World.
+ */
+$value = (int) apply_filters('filter',$foo);
+assertType('int', $value);
+
 /**
  * Typed array passed through `list()`.
  *

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -7,6 +7,17 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 use function apply_filters;
 use function PHPStan\Testing\assertType;
 
+/**
+ * Returns the passed value.
+ *
+ * @template T
+ * @param T $value Value.
+ * @return T Value.
+ */
+function return_value( $value ) {
+    return $value;
+}
+
 $value = apply_filters('filter','Hello, World');
 assertType('mixed', $value);
 
@@ -66,3 +77,11 @@ assertType('string|null', $value);
  */
 $value = apply_filters('filter',$foo);
 assertType('array', $value);
+
+/**
+ * Value assignment wrapped inside another function.
+ *
+ * @param string $foo Hello, World.
+ */
+$value = return_value(apply_filters('filter',$foo));
+assertType('string', $value);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function apply_filters;
+use function PHPStan\Testing\assertType;
+use stdClass;
+
+$value = apply_filters('filter','Hello, World');
+assertType('mixed', $value);
+
+/**
+ * Single type.
+ *
+ * @param string $foo Hello, World.
+ */
+$value = apply_filters('filter',$foo);
+assertType('string', $value);
+
+/**
+ * Union type.
+ *
+ * @param string|null $foo Hello, World.
+ */
+$value = apply_filters('filter',$foo);
+assertType('string|null', $value);
+
+/**
+ * WordPress array hash notation.
+ *
+ * @param array $foo {
+ *     Hello, World.
+ *
+ *     @type string $bar Bar.
+ * }
+ */
+$value = apply_filters('filter',$foo);
+assertType('array', $value);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -6,6 +6,7 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 
 use function apply_filters;
 use function PHPStan\Testing\assertType;
+use WP_Post;
 
 $value = apply_filters('filter','Hello, World');
 assertType('mixed', $value);
@@ -120,6 +121,22 @@ assertType('mixed', $value);
  */
 $value = (int) apply_filters('filter',$foo);
 assertType('int', $value);
+
+/**
+ * Global class that's been imported.
+ *
+ * @param WP_Post|null $foo Hello, World.
+ */
+$value = apply_filters('filter',$foo);
+assertType('WP_Post|null', $value);
+
+/**
+ * Global class that's not been imported.
+ *
+ * @param \WP_Term|null $foo Hello, World.
+ */
+$value = apply_filters('filter',$foo);
+assertType('WP_Term|null', $value);
 
 /**
  * Constant string type.

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -63,9 +63,6 @@ assertType('string', $value);
 /**
  * Single constant of a type that differs from the docblock.
  *
- * @TODO Need to decide whether this should result in a type of `string|int` or whether we can
- * get PHPStan to trigger a warning in this situation.
- *
  * @param string $foo Hello, World.
  */
 $value = apply_filters('filter',123);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -40,6 +40,19 @@ $value = apply_filters('filter',$foo);
 assertType('string', $value);
 
 /**
+ * Multiple lines and multiple parameters.
+ *
+ * @param string $foo Hello.
+ * @param bool   $bar World.
+ */
+$value = apply_filters(
+    'filter',
+    $foo,
+    $bar
+);
+assertType('string', $value);
+
+/**
  * Single constant type.
  *
  * @param string $foo Hello, World.
@@ -87,7 +100,7 @@ $value = return_value(apply_filters('filter',$foo));
 assertType('string', $value);
 
 /**
- * Filters the maximum image size dimensions for the editor.
+ * Typed array passed through `list()`.
  *
  * @since 2.5.0
  *

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -180,3 +180,41 @@ assertType('123|string', $slug);
 /** This filter is documented in foo.php */
 $value = apply_filters('foo', 123);
 assertType('mixed', $value);
+
+class ApplyFiltersTestClass {
+    public function MyMethod() {
+        /**
+         * Documented filter within a method.
+         *
+         * @param float $foo Hello, World.
+         */
+        $value = apply_filters('filter',$foo);
+        assertType('float', $value);
+    }
+
+    /**
+     * This is the method docblock, not the filter docblock. The
+     * filter does not have a docblock.
+     *
+     * @param int $foo Hello, World.
+     */
+    public function MyMethodWithParams(int $foo) {
+        $value = apply_filters('filter',$foo);
+        assertType('mixed', $value);
+    }
+
+    /**
+     * This is the method docblock, not the filter docblock.
+     *
+     * @param int $foo Hello, World.
+     */
+    public function AnotherMethodWithParams(int $foo) {
+        /**
+         * This is the filter docblock.
+         *
+         * @param string $bar Hello, World.
+         */
+        $value = apply_filters('filter',$bar);
+        assertType('string', $value);
+    }
+}

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -7,12 +7,6 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 use function apply_filters;
 use function PHPStan\Testing\assertType;
 
-// This assertion is here because any value that passes through `return_value()`
-// has a type of `*ERROR*` and I don't know why. It works fine on the playground:
-// https://phpstan.org/r/d7b65195-af14-40cf-a216-9b70bdda21c0
-$value = return_value(123);
-assertType('int', $value);
-
 $value = apply_filters('filter','Hello, World');
 assertType('mixed', $value);
 

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -156,6 +156,16 @@ list($max_width, $max_height) = apply_filters('editor_max_image_size', [$max_wid
 assertType('int', $max_width);
 assertType('int', $max_height);
 
+/**
+ * Filter inside a ternary.
+ *
+ * @param string          $slug The editable slug. Will be either a term slug or post URI depending
+ *                              upon the context in which it is evaluated.
+ * @param WP_Term|WP_Post $tag  Term or post object.
+ */
+$slug = isset($tag->slug) ? apply_filters('editable_slug', $tag->slug, $tag) : 123;
+assertType('string|int', $slug);
+
 /** This filter is documented in foo.php */
 $value = apply_filters('foo', 123);
 assertType('mixed', $value);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -136,6 +136,14 @@ $value = (int) apply_filters('filter',$foo);
 assertType('int', $value);
 
 /**
+ * Constant string type.
+ *
+ * @param 'aaa'|'bbb' $foo Hello, World.
+ */
+$value = apply_filters('filter',$foo);
+assertType("'aaa'|'bbb'", $value);
+
+/**
  * Typed array passed through `list()`.
  *
  * @since 2.5.0

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -169,7 +169,7 @@ assertType('int', $max_height);
  * @param WP_Term|WP_Post $tag  Term or post object.
  */
 $slug = isset($tag->slug) ? apply_filters('editable_slug', $tag->slug, $tag) : 123;
-assertType('string|int', $slug);
+assertType('123|string', $slug);
 
 /** This filter is documented in foo.php */
 $value = apply_filters('foo', 123);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -20,6 +20,25 @@ $value = apply_filters('filter',$foo);
 assertType('string', $value);
 
 /**
+ * Single constant type.
+ *
+ * @param string $foo Hello, World.
+ */
+$value = apply_filters('filter','I am a string');
+assertType('string', $value);
+
+/**
+ * Single constant of a type that differs from the docblock.
+ *
+ * @TODO Need to decide whether this should result in a type of `string|int` or whether we can
+ * get PHPStan to trigger a warning in this situation.
+ *
+ * @param string $foo Hello, World.
+ */
+$value = apply_filters('filter',123);
+assertType('string', $value);
+
+/**
  * Union type.
  *
  * @param string|null $foo Hello, World.

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -86,20 +86,6 @@ assertType('array', $value);
 $value = return_value(apply_filters('filter',$foo));
 assertType('string', $value);
 
-$value = return_value(
-    return_value(
-        return_value(
-            /**
-             * Multiple nested function calls.
-             *
-             * @param string $foo Hello, World.
-             */
-            apply_filters('filter',$foo)
-        )
-    )
-);
-assertType('string', $value);
-
 /**
  * Incorrect docblock placement that should be ignored.
  *

--- a/tests/testTest.php
+++ b/tests/testTest.php
@@ -16,6 +16,7 @@ class DynamicReturnTypeExtensionTests extends TypeInferenceTestCase
     {
         // path to a file with actual asserts of expected types:
         yield from $this->gatherAssertTypes(__DIR__ . '/data/_get_list_table.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/apply_filters.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_comment.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');


### PR DESCRIPTION
The return type of `apply_filters()` is indeterminate (therefore `mixed`). The return type is often wider than the type of the `$value` parameter being passed in, so it's not a generic function.

What we could do is introduce a dynamic function return type extension which reads the types from the docblock (if present) and treat those as the possible return types. This then places the burden on the developer to ensure the docblock is correct and subsequent code handles all possible return types.

Strictly, the only correct return type for `apply_filters()` is `mixed` because any filter can return a value of any type. In reality most code that uses `apply_filters()` assumes that it returns a value of the expected type. I need to give some more thought into whether treating the types in the docblock as absolute is more valuable than sticking with `mixed`.