### PR TITLE
Fix compatibility of WP_Nav_Menu_Item with WP_Post

### DIFF
--- a/example/class-wp-nav-menu-item.php
+++ b/example/class-wp-nav-menu-item.php
@@ -11,7 +11,7 @@
 /**
  * Decorates a menu item (WP_Post) object with the shared navigation menu item properties.
  */
-class WP_Nav_Menu_Item {
+class WP_Nav_Menu_Item extends WP_Post {
 
 	/**
 	 * The term_id if the menu item represents a taxonomy term.


### PR DESCRIPTION
This adds compatibility of `WP_Nav_Menu_Item` with `WP_Post` by letting `WP_Nav_Menu_Item` inherit from `WP_Post`.

Fixes #71