### PR TITLE
Configure CS for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
             "@test:phpstan"
         ],
         "test:phpunit": "phpunit",
-        "test:cs": "phpcs --standard=PSR12NeutronRuleset --exclude=PEAR.Commenting.ClassComment,PEAR.Commenting.FileComment,Generic.Files.LineLength bootstrap.php src/",
+        "test:cs": "phpcs",
+        "test:cs:fix": "phpcbf",
         "test:phpstan": "phpstan analyze",
         "test:syntax": "parallel-lint bootstrap.php src/"
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<ruleset>
+	<file>bootstrap.php</file>
+	<file>src/</file>
+	<file>tests/</file>
+
+	<rule ref="PSR12NeutronRuleset">
+		<exclude name="Generic.Files.LineLength"/>
+		<exclude name="PEAR.Commenting.ClassComment"/>
+		<exclude name="PEAR.Commenting.FileComment"/>
+	</rule>
+
+	<rule ref="NeutronStandard.Functions.TypeHint">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="NeutronStandard.Globals.DisallowGlobalFunctions">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.PHP.DiscouragedPHPFunctions">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.Security.NonceVerification">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+</ruleset>

--- a/tests/DynamicReturnTypeExtensionTests.php
+++ b/tests/DynamicReturnTypeExtensionTests.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
-use PHPStan\Testing\TypeInferenceTestCase;
-
-class DynamicReturnTypeExtensionTests extends TypeInferenceTestCase
+class DynamicReturnTypeExtensionTests extends \PHPStan\Testing\TypeInferenceTestCase
 {
 
     /**
@@ -28,11 +26,7 @@ class DynamicReturnTypeExtensionTests extends TypeInferenceTestCase
      * @dataProvider dataFileAsserts
      * @param array<string> ...$args
      */
-    public function testFileAsserts(
-        string $assertType,
-        string $file,
-        ...$args
-    ): void
+    public function testFileAsserts(string $assertType, string $file, ...$args): void
     {
         $this->assertFileAsserts($assertType, $file, ...$args);
     }
@@ -42,6 +36,4 @@ class DynamicReturnTypeExtensionTests extends TypeInferenceTestCase
         // path to your project's phpstan.neon, or extension.neon in case of custom extension packages
         return [__DIR__ . '/../extension.neon'];
     }
-
 }
-

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,14 +7,4 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 error_reporting(E_ALL);
 
 require_once __DIR__ . '/../vendor/autoload.php';
-
-/**
- * Returns the passed value.
- *
- * @template T
- * @param T $value Value.
- * @return T Value.
- */
-function return_value( $value ) {
-    return $value;
-}
+require_once __DIR__ . '/functions.php';

--- a/tests/data/ApplyFiltersTestClass.php
+++ b/tests/data/ApplyFiltersTestClass.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests\data;
+
+use function PHPStan\Testing\assertType;
+
+class ApplyFiltersTestClass
+{
+    public function myMethod()
+    {
+        $foo = 0.0;
+
+        /**
+         * Documented filter within a method.
+         *
+         * @param float $foo Hello, World.
+         */
+        $value = apply_filters('filter', $foo);
+        assertType('float', $value);
+    }
+
+    /**
+     * This is the method docblock, not the filter docblock. The
+     * filter does not have a docblock.
+     *
+     * @param int $foo Hello, World.
+     */
+    public function myMethodWithParams(int $foo)
+    {
+        $value = apply_filters('filter', $foo);
+        assertType('mixed', $value);
+    }
+
+    /**
+     * This is the method docblock, not the filter docblock.
+     *
+     * @param int $foo Hello, World.
+     */
+    public function anotherMethodWithParams(int $foo) // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    {
+        $bar = '';
+
+        /**
+         * This is the filter docblock.
+         *
+         * @param string $bar Hello, World.
+         */
+        $value = apply_filters('filter', $bar);
+        assertType('string', $value);
+    }
+}

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -2,23 +2,25 @@
 
 declare(strict_types=1);
 
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
-use function apply_filters;
 use function PHPStan\Testing\assertType;
-use WP_Post;
+use function apply_filters;
+use function returnValue;
 
-$value = apply_filters('filter','Hello, World');
+$value = apply_filters('filter', 'Hello, World');
 assertType('mixed', $value);
 
 /**
  * Unknown parameter.
  */
-$value = apply_filters('filter',$foo);
+$value = apply_filters('filter', $foo);
 assertType('mixed', $value);
 
-/** @var int $value */
-$value = apply_filters('filter',$foo);
+/** @var int $value */ // phpcs:ignore SlevomatCodingStandard.PHP.RequireExplicitAssertion
+$value = apply_filters('filter', $foo);
 assertType('int', $value);
 
 /**
@@ -26,7 +28,7 @@ assertType('int', $value);
  *
  * @param string $foo Hello, World.
  */
-$value = apply_filters('filter',$foo);
+$value = apply_filters('filter', $foo);
 assertType('string', $value);
 
 /**
@@ -47,7 +49,7 @@ assertType('string', $value);
  *
  * @param string $foo Hello, World.
  */
-$value = apply_filters('filter','I am a string');
+$value = apply_filters('filter', 'I am a string');
 assertType('string', $value);
 
 /**
@@ -55,7 +57,7 @@ assertType('string', $value);
  *
  * @param string $foo Hello, World.
  */
-$value = apply_filters('filter',123);
+$value = apply_filters('filter', 123);
 assertType('string', $value);
 
 /**
@@ -63,7 +65,7 @@ assertType('string', $value);
  *
  * @param string|null $foo Hello, World.
  */
-$value = apply_filters('filter',$foo);
+$value = apply_filters('filter', $foo);
 assertType('string|null', $value);
 
 /**
@@ -75,7 +77,7 @@ assertType('string|null', $value);
  *     @type string $bar Bar.
  * }
  */
-$value = apply_filters('filter',$foo);
+$value = apply_filters('filter', $foo);
 assertType('array', $value);
 
 /**
@@ -83,7 +85,7 @@ assertType('array', $value);
  *
  * @param string $foo Hello, World.
  */
-$value = return_value(apply_filters('filter',$foo));
+$value = returnValue(apply_filters('filter', $foo));
 assertType('string', $value);
 
 /**
@@ -91,10 +93,10 @@ assertType('string', $value);
  *
  * @param string $foo Hello, World.
  */
-$value = return_value(
-    return_value(
-        return_value(
-            apply_filters('filter',$foo)
+$value = returnValue(
+    returnValue(
+        returnValue(
+            apply_filters('filter', $foo)
         )
     )
 );
@@ -105,15 +107,15 @@ assertType('mixed', $value);
  *
  * @param float|int|null $foo Hello, World.
  */
-$value = (int) apply_filters('filter',$foo);
+$value = (int)apply_filters('filter', $foo);
 assertType('int', $value);
 
 /**
  * Global class that's been imported.
  *
- * @param WP_Post|null $foo Hello, World.
+ * @param \WP_Post|null $foo Hello, World.
  */
-$value = apply_filters('filter',$foo);
+$value = apply_filters('filter', $foo);
 assertType('WP_Post|null', $value);
 
 /**
@@ -121,7 +123,7 @@ assertType('WP_Post|null', $value);
  *
  * @param \WP_Term|null $foo Hello, World.
  */
-$value = apply_filters('filter',$foo);
+$value = apply_filters('filter', $foo);
 assertType('WP_Term|null', $value);
 
 /**
@@ -129,7 +131,7 @@ assertType('WP_Term|null', $value);
  *
  * @param 'aaa'|'bbb' $foo Hello, World.
  */
-$value = apply_filters('filter',$foo);
+$value = apply_filters('filter', $foo);
 assertType("'aaa'|'bbb'", $value);
 
 /**
@@ -137,28 +139,27 @@ assertType("'aaa'|'bbb'", $value);
  *
  * @since 2.5.0
  *
- * @param int[]        $max_image_size {
- *     An array of width and height values.
- *
- *     @type int $0 The maximum width in pixels.
- *     @type int $1 The maximum height in pixels.
+ * @param array<int> $max_image_size {
+ * An array of width and height values.
+ * @type int $0 The maximum width in pixels.
+ * @type int $1 The maximum height in pixels.
  * }
- * @param string|int[] $size     Requested image size. Can be any registered image size name, or
- *                               an array of width and height values in pixels (in that order).
+ * @param string|array<int> $size Requested image size. Can be any registered image size name, or
+ * an array of width and height values in pixels (in that order).
  * @param string       $context  The context the image is being resized for.
  *                               Possible values are 'display' (like in a theme)
  *                               or 'edit' (like inserting into an editor).
  */
-list($max_width, $max_height) = apply_filters('editor_max_image_size', [$max_width, $max_height], $size, $context);
-assertType('int', $max_width);
-assertType('int', $max_height);
+[$maxWidth, $maxHeight] = apply_filters('editor_max_image_size', [$maxWidth, $maxHeight], $size, $context);
+assertType('int', $maxWidth);
+assertType('int', $maxHeight);
 
 /**
  * Filter inside a ternary.
  *
  * @param string          $slug The editable slug. Will be either a term slug or post URI depending
  *                              upon the context in which it is evaluated.
- * @param WP_Term|WP_Post $tag  Term or post object.
+ * @param \WP_Term|\WP_Post $tag Term or post object.
  */
 $slug = isset($tag->slug) ? apply_filters('editable_slug', $tag->slug, $tag) : 123;
 assertType('123|string', $slug);
@@ -166,41 +167,3 @@ assertType('123|string', $slug);
 /** This filter is documented in foo.php */
 $value = apply_filters('foo', 123);
 assertType('mixed', $value);
-
-class ApplyFiltersTestClass {
-    public function MyMethod() {
-        /**
-         * Documented filter within a method.
-         *
-         * @param float $foo Hello, World.
-         */
-        $value = apply_filters('filter',$foo);
-        assertType('float', $value);
-    }
-
-    /**
-     * This is the method docblock, not the filter docblock. The
-     * filter does not have a docblock.
-     *
-     * @param int $foo Hello, World.
-     */
-    public function MyMethodWithParams(int $foo) {
-        $value = apply_filters('filter',$foo);
-        assertType('mixed', $value);
-    }
-
-    /**
-     * This is the method docblock, not the filter docblock.
-     *
-     * @param int $foo Hello, World.
-     */
-    public function AnotherMethodWithParams(int $foo) {
-        /**
-         * This is the filter docblock.
-         *
-         * @param string $bar Hello, World.
-         */
-        $value = apply_filters('filter',$bar);
-        assertType('string', $value);
-    }
-}

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+// phpcs:disable SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
@@ -139,13 +140,14 @@ assertType("'aaa'|'bbb'", $value);
  *
  * @since 2.5.0
  *
- * @param array<int> $max_image_size {
- * An array of width and height values.
- * @type int $0 The maximum width in pixels.
- * @type int $1 The maximum height in pixels.
+ * @param int[]        $max_image_size {
+ *     An array of width and height values.
+ *
+ *     @type int $0 The maximum width in pixels.
+ *     @type int $1 The maximum height in pixels.
  * }
- * @param string|array<int> $size Requested image size. Can be any registered image size name, or
- * an array of width and height values in pixels (in that order).
+ * @param string|int[] $size     Requested image size. Can be any registered image size name, or
+ *                               an array of width and height values in pixels (in that order).
  * @param string       $context  The context the image is being resized for.
  *                               Possible values are 'display' (like in a theme)
  *                               or 'edit' (like inserting into an editor).

--- a/tests/data/current_time.php
+++ b/tests/data/current_time.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
-use function current_time;
-use function PHPStan\Testing\assertType;
 use stdClass;
 
+use function current_time;
+use function PHPStan\Testing\assertType;
+
 // Integer types
+// phpcs:disable WordPress.DateTime.CurrentTimeTimestamp.Requested
 assertType('int', current_time('timestamp'));
 assertType('int', current_time('U'));
+// phpcs:enable
 
 // String types
 assertType('string', current_time('mysql'));
@@ -21,5 +24,5 @@ assertType('int|string', current_time($_GET['foo']));
 assertType('int|string', current_time(get_option('date_format')));
 
 // Unsupported types
-assertType('int|string', current_time(new stdClass));
+assertType('int|string', current_time(new stdClass()));
 assertType('int|string', current_time(false));

--- a/tests/data/get_comment.php
+++ b/tests/data/get_comment.php
@@ -8,14 +8,14 @@ use function PHPStan\Testing\assertType;
 
 // Default output
 assertType('WP_Comment|null', get_comment(1));
-assertType('WP_Comment|null', get_comment(1,OBJECT));
-assertType('WP_Comment|null', get_comment(1,'Hello'));
+assertType('WP_Comment|null', get_comment(1, OBJECT));
+assertType('WP_Comment|null', get_comment(1, 'Hello'));
 
 // Unknown output
-assertType('array|\WP_Comment|null', get_comment(1,$_GET['foo']));
+assertType('array|\WP_Comment|null', get_comment(1, $_GET['foo']));
 
 // Associative array output
-assertType('array<string, mixed>|null', get_comment(1,ARRAY_A));
+assertType('array<string, mixed>|null', get_comment(1, ARRAY_A));
 
 // Numeric array output
-assertType('array<int, mixed>|null', get_comment(1,ARRAY_N));
+assertType('array<int, mixed>|null', get_comment(1, ARRAY_N));

--- a/tests/data/get_object_taxonomies.php
+++ b/tests/data/get_object_taxonomies.php
@@ -8,11 +8,11 @@ use function PHPStan\Testing\assertType;
 
 // Default output
 assertType('array<int, string>', get_object_taxonomies('post'));
-assertType('array<int, string>', get_object_taxonomies('post','names'));
-assertType('array<int, string>', get_object_taxonomies('post','Hello'));
+assertType('array<int, string>', get_object_taxonomies('post', 'names'));
+assertType('array<int, string>', get_object_taxonomies('post', 'Hello'));
 
 // Unknown output
-assertType('array<string|\WP_Taxonomy>', get_object_taxonomies('post',$_GET['foo']));
+assertType('array<string|\WP_Taxonomy>', get_object_taxonomies('post', $_GET['foo']));
 
 // Objects output
-assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post','objects'));
+assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post', 'objects'));

--- a/tests/data/get_post.php
+++ b/tests/data/get_post.php
@@ -8,14 +8,14 @@ use function PHPStan\Testing\assertType;
 
 // Default output
 assertType('WP_Post|null', get_post(1));
-assertType('WP_Post|null', get_post(1,OBJECT));
-assertType('WP_Post|null', get_post(1,'Hello'));
+assertType('WP_Post|null', get_post(1, OBJECT));
+assertType('WP_Post|null', get_post(1, 'Hello'));
 
 // Unknown output
-assertType('array|\WP_Post|null', get_post(1,$_GET['foo']));
+assertType('array|\WP_Post|null', get_post(1, $_GET['foo']));
 
 // Associative array output
-assertType('array<string, mixed>|null', get_post(1,ARRAY_A));
+assertType('array<string, mixed>|null', get_post(1, ARRAY_A));
 
 // Numeric array output
-assertType('array<int, mixed>|null', get_post(1,ARRAY_N));
+assertType('array<int, mixed>|null', get_post(1, ARRAY_N));

--- a/tests/data/mysql2date.php
+++ b/tests/data/mysql2date.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
+use stdClass;
+
 use function PHPStan\Testing\assertType;
 
 $time = '1970-01-01 00:00:00';
@@ -19,5 +21,5 @@ assertType('int|string|false', mysql2date($_GET['foo'], $time));
 assertType('int|string|false', mysql2date(get_option('date_format'), $time));
 
 // Unsupported types
-assertType('int|string|false', mysql2date(new \stdClass(), $time));
+assertType('int|string|false', mysql2date(new stdClass(), $time));
 assertType('int|string|false', mysql2date(false, $time));

--- a/tests/data/mysql2date.php
+++ b/tests/data/mysql2date.php
@@ -19,5 +19,5 @@ assertType('int|string|false', mysql2date($_GET['foo'], $time));
 assertType('int|string|false', mysql2date(get_option('date_format'), $time));
 
 // Unsupported types
-assertType('int|string|false', mysql2date(new \stdClass, $time));
+assertType('int|string|false', mysql2date(new \stdClass(), $time));
 assertType('int|string|false', mysql2date(false, $time));

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Returns the passed value.
+ *
+ * @template T
+ * @param T $value Value.
+ * @return T Value.
+ */
+function returnValue( $value )
+{
+    return $value;
+}


### PR DESCRIPTION
Related to or part of #75. To make things easier I'm planning to create one PR per tool.

To allow simpler automagic fixing, I converted the inline phpcs arguments into a phpcs.xml.dist config file and added a `test:cs:fix` script. Most of the simple changes here were done with that. I also ignored some rules for the tests completely as they do not make much sense there IMO or are not workig as expected (e.g. `NeutronStandard.Functions.TypeHint` complains about a missing return type hint if `iterable` is used).

Let me know what you think