### PR TITLE
Fix unit tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
 >
 	<testsuites>
 		<testsuite name="main">
-			<directory suffix="Test.php">./tests/</directory>
+			<directory>./tests/</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
-class DynamicReturnTypeExtensionTests extends \PHPStan\Testing\TypeInferenceTestCase
+class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestCase
 {
 
     /**


### PR DESCRIPTION
Sorry, I broke them in #79 by renaming this file (phpunit did not execute those tests any more). This PR renames it again and removes the custom suffix config for phpunit. Unit tests should be running again now :)