### PR TITLE
Comment out ignore rule for `load_plugin_textdomain()`

### DIFF
--- a/example/phpstan-full.neon
+++ b/example/phpstan-full.neon
@@ -33,8 +33,8 @@ parameters:
         #- '#^Function wp_sprintf invoked with [23456] parameters, 1 required\.$#'
         #- '#^Function add_post_type_support invoked with [345] parameters, 2 required\.$#'
         #- '#^Function ((get|add)_theme_support|current_theme_supports) invoked with [2345] parameters, 1 required\.$#'
-        # https://core.trac.wordpress.org/ticket/43304
-        - '/^Parameter #2 \$deprecated of function load_plugin_textdomain expects string, false given\.$/'
+        # Fixed in WordPress 5.2 - https://core.trac.wordpress.org/ticket/43304
+        #- '/^Parameter #2 \$deprecated of function load_plugin_textdomain expects string, false given\.$/'
         # WP-CLI accepts a class name as callable
         - '/^Parameter #2 \$callable of static method WP_CLI::add_command\(\) expects callable\(\): mixed, \S+ given\.$/'
         # Please consider commenting ignores: issue URL or reason for ignoring


### PR DESCRIPTION
The `@param` type for the `$deprecated` and `$plugin_rel_path` arguments of `load_plugin_textdomain()` have been corrected in WP 5.2.

See https://github.com/WordPress/wordpress-develop/blob/5.2/src/wp-includes/l10n.php#L760-L777 vs. https://github.com/WordPress/wordpress-develop/blob/5.1/src/wp-includes/l10n.php#L760-L776.