### PR TITLE
More tests for the return type of `apply_filters()` and related functions

### DIFF
--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -169,3 +169,21 @@ assertType('123|string', $slug);
 /** This filter is documented in foo.php */
 $value = apply_filters('foo', 123);
 assertType('mixed', $value);
+
+/**
+ * Return type for `apply_filters_ref_array()`.
+ *
+ * @param string $foo Hello.
+ * @param int    $bar World.
+ */
+$value = apply_filters_ref_array('foo', ['Hello',123]);
+assertType('string', $value);
+
+/**
+ * Return type for `apply_filters_deprecated()`.
+ *
+ * @param string $foo Hello.
+ * @param bool   $bar World.
+ */
+$value = apply_filters_deprecated('foo', 'Hello', true);
+assertType('string', $value);

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -176,7 +176,7 @@ assertType('mixed', $value);
  * @param string $foo Hello.
  * @param int    $bar World.
  */
-$value = apply_filters_ref_array('foo', ['Hello',123]);
+$value = apply_filters_ref_array('foo', ['Hello', 123]);
 assertType('string', $value);
 
 /**


### PR DESCRIPTION
Adds some test coverage for `apply_filters_ref_array()` and `apply_filters_deprecated()` which are also covered by the dynamic function return type extension. It's not comprehensive but it demonstrates that these functions are covered.