### PR TITLE
Use the same version of PHP Parser that PHPStan uses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     "require-dev": {
         "composer/composer": "^1.10.23",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "nikic/php-parser": "< 4.13.0",
         "php-parallel-lint/php-parallel-lint": "^1.1",
         "phpstan/phpstan-strict-rules": "^1.0",
         "phpunit/phpunit": "^7 || ^9",

--- a/src/CurrentTimeDynamicFunctionReturnTypeExtension.php
+++ b/src/CurrentTimeDynamicFunctionReturnTypeExtension.php
@@ -29,13 +29,14 @@ class CurrentTimeDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyn
      */
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
-        $argumentType = $scope->getType($functionCall->args[0]->value);
+        $args = $functionCall->getArgs();
+        $argumentType = $scope->getType($args[0]->value);
 
         // When called with a $type that isn't a constant string, return default return type
         if (! $argumentType instanceof ConstantStringType) {
             return ParametersAcceptorSelector::selectFromArgs(
                 $scope,
-                $functionCall->args,
+                $args,
                 $functionReflection->getVariants()
             )->getReturnType();
         }

--- a/src/GetCommentDynamicFunctionReturnTypeExtension.php
+++ b/src/GetCommentDynamicFunctionReturnTypeExtension.php
@@ -34,22 +34,23 @@ class GetCommentDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
         $output = 'OBJECT';
+        $args = $functionCall->getArgs();
 
-        if (count($functionCall->args) >= 2) {
-            $argumentType = $scope->getType($functionCall->args[1]->value);
+        if (count($args) >= 2) {
+            $argumentType = $scope->getType($args[1]->value);
 
             // When called with an $output that isn't a constant string, return default return type
             if (! $argumentType instanceof ConstantStringType) {
                 return ParametersAcceptorSelector::selectFromArgs(
                     $scope,
-                    $functionCall->args,
+                    $args,
                     $functionReflection->getVariants()
                 )->getReturnType();
             }
         }
 
-        if (count($functionCall->args) >= 2 && $functionCall->args[1]->value instanceof ConstFetch) {
-            $output = $functionCall->args[1]->value->name->getLast();
+        if (count($args) >= 2 && $args[1]->value instanceof ConstFetch) {
+            $output = $args[1]->value->name->getLast();
         }
         if ($output === 'ARRAY_A') {
             return TypeCombinator::union(new ArrayType(new StringType(), new MixedType()), new NullType());

--- a/src/GetListTableDynamicFunctionReturnTypeExtension.php
+++ b/src/GetListTableDynamicFunctionReturnTypeExtension.php
@@ -28,18 +28,20 @@ class GetListTableDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
+        $args = $functionCall->getArgs();
+
         // Called without $class argument
-        if (count($functionCall->args) < 1) {
+        if (count($args) < 1) {
             return new ConstantBooleanType(false);
         }
 
-        $argumentType = $scope->getType($functionCall->args[0]->value);
+        $argumentType = $scope->getType($args[0]->value);
 
         // When called with a $class that isn't a constant string, return default return type
         if (! $argumentType instanceof ConstantStringType) {
             return ParametersAcceptorSelector::selectFromArgs(
                 $scope,
-                $functionCall->args,
+                $args,
                 $functionReflection->getVariants()
             )->getReturnType();
         }

--- a/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
@@ -33,18 +33,20 @@ class GetObjectTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\
      */
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
+        $args = $functionCall->getArgs();
+
         // Called without second $output argument
-        if (count($functionCall->args) <= 1) {
+        if (count($args) <= 1) {
             return new ArrayType(new IntegerType(), new StringType());
         }
 
-        $argumentType = $scope->getType($functionCall->args[1]->value);
+        $argumentType = $scope->getType($args[1]->value);
 
         // When called with an $output that isn't a constant string, return default return type
         if (! $argumentType instanceof ConstantStringType) {
             return ParametersAcceptorSelector::selectFromArgs(
                 $scope,
-                $functionCall->args,
+                $args,
                 $functionReflection->getVariants()
             )->getReturnType();
         }

--- a/src/GetPostDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostDynamicFunctionReturnTypeExtension.php
@@ -34,22 +34,23 @@ class GetPostDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynamic
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
         $output = 'OBJECT';
+        $args = $functionCall->getArgs();
 
         if (count($functionCall->args) >= 2) {
-            $argumentType = $scope->getType($functionCall->args[1]->value);
+            $argumentType = $scope->getType($args[1]->value);
 
             // When called with an $output that isn't a constant string, return default return type
             if (! $argumentType instanceof ConstantStringType) {
                 return ParametersAcceptorSelector::selectFromArgs(
                     $scope,
-                    $functionCall->args,
+                    $args,
                     $functionReflection->getVariants()
                 )->getReturnType();
             }
         }
 
-        if (count($functionCall->args) >= 2 && $functionCall->args[1]->value instanceof ConstFetch) {
-            $output = $functionCall->args[1]->value->name->getLast();
+        if (count($args) >= 2 && $args[1]->value instanceof ConstFetch) {
+            $output = $args[1]->value->name->getLast();
         }
         if ($output === 'ARRAY_A') {
             return TypeCombinator::union(new ArrayType(new StringType(), new MixedType()), new NullType());

--- a/src/GetPostsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostsDynamicFunctionReturnTypeExtension.php
@@ -31,12 +31,14 @@ class GetPostsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
+        $args = $functionCall->getArgs();
+
         // Called without arguments
-        if (count($functionCall->args) === 0) {
+        if (count($args) === 0) {
             return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));
         }
 
-        $argumentType = $scope->getType($functionCall->args[0]->value);
+        $argumentType = $scope->getType($args[0]->value);
 
         // Called with an array argument
         if ($argumentType instanceof ConstantArrayType) {

--- a/src/GetTaxonomiesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetTaxonomiesDynamicFunctionReturnTypeExtension.php
@@ -39,12 +39,14 @@ class GetTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\D
             $namesReturnType
         );
 
+        $args = $functionCall->getArgs();
         // Called without second $output arguments
-        if (count($functionCall->args) <= 1) {
+
+        if (count($args) <= 1) {
             return $namesReturnType;
         }
 
-        $argumentType = $scope->getType($functionCall->args[1]->value);
+        $argumentType = $scope->getType($args[1]->value);
 
         // When called with a non-string $output, return default return type
         if (! $argumentType instanceof ConstantStringType) {

--- a/src/IsWpErrorFunctionTypeSpecifyingExtension.php
+++ b/src/IsWpErrorFunctionTypeSpecifyingExtension.php
@@ -35,7 +35,9 @@ class IsWpErrorFunctionTypeSpecifyingExtension implements \PHPStan\Type\Function
             throw new \PHPStan\ShouldNotHappenException();
         }
 
-        return $this->typeSpecifier->create($node->args[0]->value, new ObjectType('WP_Error'), $context);
+        $args = $node->getArgs();
+
+        return $this->typeSpecifier->create($args[0]->value, new ObjectType('WP_Error'), $context);
     }
 
     public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/src/MySQL2DateDynamicFunctionReturnTypeExtension.php
+++ b/src/MySQL2DateDynamicFunctionReturnTypeExtension.php
@@ -31,13 +31,14 @@ class MySQL2DateDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
      */
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
-        $argumentType = $scope->getType($functionCall->args[0]->value);
+        $args = $functionCall->getArgs();
+        $argumentType = $scope->getType($args[0]->value);
 
         // When called with a $format that isn't a constant string, return default return type
         if (! $argumentType instanceof ConstantStringType) {
             return ParametersAcceptorSelector::selectFromArgs(
                 $scope,
-                $functionCall->args,
+                $args,
                 $functionReflection->getVariants()
             )->getReturnType();
         }

--- a/src/ShortcodeAttsDynamicFunctionReturnTypeExtension.php
+++ b/src/ShortcodeAttsDynamicFunctionReturnTypeExtension.php
@@ -26,15 +26,16 @@ final class ShortcodeAttsDynamicFunctionReturnTypeExtension implements \PHPStan\
 
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
-        if ($functionCall->args === []) {
+        $args = $functionCall->getArgs();
+        if ($args === []) {
             return ParametersAcceptorSelector::selectFromArgs(
                 $scope,
-                $functionCall->args,
+                $args,
                 $functionReflection->getVariants()
             )->getReturnType();
         }
 
-        $type = $scope->getType($functionCall->args[0]->value);
+        $type = $scope->getType($args[0]->value);
 
         if ($type instanceof ConstantArrayType) {
             // shortcode_atts values are coming from the defined defaults or from the actual string shortcode attributes

--- a/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
+++ b/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
@@ -25,16 +25,17 @@ class StringOrArrayDynamicFunctionReturnTypeExtension implements \PHPStan\Type\D
 
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
     {
-        $argsCount = count($functionCall->args);
+        $args = $functionCall->getArgs();
+        $argsCount = count($args);
         if ($argsCount === 0) {
             return ParametersAcceptorSelector::selectFromArgs(
                 $scope,
-                $functionCall->args,
+                $args,
                 $functionReflection->getVariants()
             )->getReturnType();
         }
 
-        $dataArg = $functionCall->args[0]->value;
+        $dataArg = $args[0]->value;
         $dataArgType = $scope->getType($dataArg);
         if ($dataArgType instanceof ArrayType) {
             $keyType = $dataArgType->getIterableKeyType();


### PR DESCRIPTION
PHPStan >= 1.0 uses PHP Parser 4.13 which changed the handling of `Expr::$args`. This property should no longer be accessed directly; the `CallLike::getArgs()` method should be used instead. Release notes: https://github.com/nikic/PHP-Parser/releases/tag/v4.13.0

Here's where PHPStan made the change: https://github.com/phpstan/phpstan-src/commit/1c6ce5dfe4d16ad25ddef96a88541f7e44a3204f

The difference in behaviour is subtle and I only discovered it while working on #78. The `args` property is of type `array<Arg|VariadicPlaceholder>` but the return type of `CallLike::getArgs()` is `array<Arg>`. This means you can safely call methods on `Arg` that don't exist on `VariadicPlaceholder`.