### PR TITLE
Add a dynamic function return type extension for `term_exists()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -59,6 +59,10 @@ services:
         class: SzepeViktor\PHPStan\WordPress\WPErrorParameterDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
+        class: SzepeViktor\PHPStan\WordPress\TermExistsDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
 rules:
     - SzepeViktor\PHPStan\WordPress\HookDocsRule
 parameters:

--- a/src/HookDocBlock.php
+++ b/src/HookDocBlock.php
@@ -15,7 +15,6 @@ use PHPStan\Type\FileTypeMapper;
 
 class HookDocBlock
 {
-
     /** @var \PHPStan\Type\FileTypeMapper */
     protected $fileTypeMapper;
 

--- a/src/TermExistsDynamicFunctionReturnTypeExtension.php
+++ b/src/TermExistsDynamicFunctionReturnTypeExtension.php
@@ -67,7 +67,7 @@ class TermExistsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
             [
                 new StringType(),
                 new StringType(),
-            ],
+            ]
         );
         $withoutTaxonomy = new StringType();
 

--- a/src/TermExistsDynamicFunctionReturnTypeExtension.php
+++ b/src/TermExistsDynamicFunctionReturnTypeExtension.php
@@ -71,14 +71,14 @@ class TermExistsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
         );
         $withoutTaxonomy = new StringType();
 
-        if ((($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() !== '')) {
+        if (($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() !== '') {
             return TypeCombinator::union(
                 $withTaxonomy,
                 new NullType(),
             );
         }
 
-        if ((($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() === '')) {
+        if (($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() === '') {
             return TypeCombinator::union(
                 $withoutTaxonomy,
                 new NullType(),

--- a/src/TermExistsDynamicFunctionReturnTypeExtension.php
+++ b/src/TermExistsDynamicFunctionReturnTypeExtension.php
@@ -74,21 +74,21 @@ class TermExistsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
         if (($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() !== '') {
             return TypeCombinator::union(
                 $withTaxonomy,
-                new NullType(),
+                new NullType()
             );
         }
 
         if (($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() === '') {
             return TypeCombinator::union(
                 $withoutTaxonomy,
-                new NullType(),
+                new NullType()
             );
         }
 
         return TypeCombinator::union(
             $withTaxonomy,
             $withoutTaxonomy,
-            new NullType(),
+            new NullType()
         );
     }
 }

--- a/src/TermExistsDynamicFunctionReturnTypeExtension.php
+++ b/src/TermExistsDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,94 @@
+<?php
+
+//phpcs:disable SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+
+/**
+ * Set return type of term_exists().
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Type;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\TypeCombinator;
+
+class TermExistsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return in_array(
+            $functionReflection->getName(),
+            [
+                'is_term',
+                'tag_exists',
+                'term_exists',
+            ],
+            true
+        );
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/functions/term_exists/
+     */
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        $args = $functionCall->getArgs();
+
+        if (count($args) === 0) {
+            return new MixedType();
+        }
+
+        $termType = $scope->getType($args[0]->value);
+        $taxonomyType = isset($args[1]) ? $scope->getType($args[1]->value) : new ConstantStringType('');
+
+        if ($termType instanceof NullType) {
+            return new NullType();
+        }
+
+        if (($termType instanceof ConstantIntegerType) && $termType->getValue() === 0) {
+            return new ConstantIntegerType(0);
+        }
+
+        $withTaxonomy = new ConstantArrayType(
+            [
+                new ConstantStringType('term_id'),
+                new ConstantStringType('term_taxonomy_id'),
+            ],
+            [
+                new StringType(),
+                new StringType(),
+            ],
+        );
+        $withoutTaxonomy = new StringType();
+
+        if ((($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() !== '')) {
+            return TypeCombinator::union(
+                $withTaxonomy,
+                new NullType(),
+            );
+        }
+
+        if ((($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() === '')) {
+            return TypeCombinator::union(
+                $withoutTaxonomy,
+                new NullType(),
+            );
+        }
+
+        return TypeCombinator::union(
+            $withTaxonomy,
+            $withoutTaxonomy,
+            new NullType(),
+        );
+    }
+}

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -20,6 +20,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
     }
 

--- a/tests/data/term_exists.php
+++ b/tests/data/term_exists.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function PHPStan\Testing\assertType;
+
+$term = $_GET['term'] ?? 123;
+$taxo = $_GET['taxo'] ?? 'category';
+
+// Empty taxonomy
+assertType('string|null', term_exists(123));
+assertType('string|null', term_exists(123, ''));
+assertType('string|null', term_exists($term));
+assertType('string|null', term_exists($term, ''));
+
+// Fixed taxonomy string
+assertType('array{term_id: string, term_taxonomy_id: string}|null', term_exists(123, 'category'));
+assertType('array{term_id: string, term_taxonomy_id: string}|null', term_exists($term, 'category'));
+
+// Unknown taxonomy type
+assertType('array{term_id: string, term_taxonomy_id: string}|string|null', term_exists(123, $taxo));
+
+// Term 0
+assertType('0', term_exists(0));
+assertType('0', term_exists(0, $taxo));
+assertType('0', term_exists(0, 'category'));
+assertType('0', term_exists(0, ''));
+
+// Term null
+assertType('null', term_exists(null));
+assertType('null', term_exists(null, $taxo));
+assertType('null', term_exists(null, 'category'));
+assertType('null', term_exists(null, ''));
+
+// Oh dear
+assertType('mixed', term_exists());


### PR DESCRIPTION
The return type of `term_exists()` varies depending on its parameters. This adds a return type extension that covers this.