### PR TITLE
Introduce a dynamic return type extension for `has_filter()` and `has_action()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -44,6 +44,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: SzepeViktor\PHPStan\WordPress\HasFilterDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\ShortcodeAttsDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/HasFilterDynamicFunctionReturnTypeExtension.php
+++ b/src/HasFilterDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Set return type of has_filter() and has_action().
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Type;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\TypeCombinator;
+
+class HasFilterDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return in_array($functionReflection->getName(), ['has_filter', 'has_action'], true);
+    }
+
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        $args = $functionCall->getArgs();
+        $callbackArgumentType = new ConstantBooleanType(false);
+
+        if (isset($args[1])) {
+            $callbackArgumentType = $scope->getType($args[1]->value);
+        }
+
+        if (($callbackArgumentType instanceof ConstantBooleanType) && ($callbackArgumentType->getValue() === false)) {
+            return new BooleanType();
+        }
+
+        if ($callbackArgumentType instanceof MixedType) {
+            return TypeCombinator::union(
+                new BooleanType(),
+                new IntegerType()
+            );
+        }
+
+        return TypeCombinator::union(
+            new ConstantBooleanType(false),
+            new IntegerType()
+        );
+    }
+}

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -19,6 +19,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_terms.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');

--- a/tests/data/has_filter.php
+++ b/tests/data/has_filter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function PHPStan\Testing\assertType;
+
+// Default callback of false
+assertType('bool', has_filter(''));
+assertType('bool', has_action(''));
+
+// Explicit callback of false
+assertType('bool', has_filter('', false));
+assertType('bool', has_action('', false));
+
+// Explicit callback
+assertType('int|false', has_filter('', 'intval'));
+assertType('int|false', has_action('', 'intval'));
+
+// Unknown callback
+$callback = $_GET['callback'] ?? 'foo';
+assertType('bool|int', has_filter('', $callback));
+assertType('bool|int', has_action('', $callback));


### PR DESCRIPTION
These functions return a boolean when `$callback` is false, otherwise an integer or false.