### PR TITLE
Introduce a dynamic return type extension for functions with an `$echo` or `$display` parameter

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -60,6 +60,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: SzepeViktor\PHPStan\WordPress\EchoParameterDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\WPErrorParameterDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/EchoParameterDynamicFunctionReturnTypeExtension.php
+++ b/src/EchoParameterDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Set return type of various functions that support an `$echo` or `$display` parameter.
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VoidType;
+
+class EchoParameterDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    /**
+     * Function name and position of `$echo` parameter.
+     */
+    private const SUPPORTED_FUNCTIONS = [
+        'comment_class' => 3,
+        'edit_term_link' => 4,
+        'get_calendar' => 1,
+        'next_posts' => 1,
+        'post_type_archive_title' => 1,
+        'previous_posts' => 0,
+        'single_cat_title' => 1,
+        'single_post_title' => 1,
+        'single_tag_title' => 1,
+        'single_term_title' => 1,
+        'the_date' => 3,
+        'the_modified_date' => 3,
+        'wp_loginout' => 1,
+        'wp_register' => 2,
+        'wp_title' => 1,
+    ];
+
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return array_key_exists($functionReflection->getName(), self::SUPPORTED_FUNCTIONS);
+    }
+
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        $name = $functionReflection->getName();
+        $functionParameter = self::SUPPORTED_FUNCTIONS[$name] ?? null;
+        $args = $functionCall->getArgs();
+
+        if ($functionParameter === null) {
+            throw new \PHPStan\ShouldNotHappenException(
+                sprintf(
+                    'Could not detect return types for function %s()',
+                    $name
+                )
+            );
+        }
+
+        $echoArgumentType = new ConstantBooleanType(true);
+
+        if (isset($args[$functionParameter])) {
+            $echoArgumentType = $scope->getType($args[$functionParameter]->value);
+        }
+
+        if ($echoArgumentType instanceof ConstantBooleanType) {
+            return ($echoArgumentType->getValue() === false)
+                ? new StringType()
+                : new VoidType();
+        }
+
+        return TypeCombinator::union(
+            new StringType(),
+            new VoidType()
+        );
+    }
+}

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -15,6 +15,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from $this->gatherAssertTypes(__DIR__ . '/data/_get_list_table.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/apply_filters.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/echo_parameter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_comment.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post.php');

--- a/tests/data/echo_parameter.php
+++ b/tests/data/echo_parameter.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function PHPStan\Testing\assertType;
+
+// Default value of true
+assertType('void', comment_class());
+assertType('void', edit_term_link());
+assertType('void', get_calendar());
+assertType('void', next_posts());
+assertType('void', post_type_archive_title());
+assertType('void', previous_posts());
+assertType('void', single_cat_title());
+assertType('void', single_post_title());
+assertType('void', single_tag_title());
+assertType('void', single_term_title());
+assertType('void', the_date());
+assertType('void', the_modified_date());
+assertType('void', wp_loginout());
+assertType('void', wp_register());
+assertType('void', wp_title());
+
+// Explicit value of true
+$value = true;
+assertType('void', comment_class('', null, null, $value));
+assertType('void', edit_term_link('', '', '', null, $value));
+assertType('void', get_calendar(true, $value));
+assertType('void', next_posts(0, $value));
+assertType('void', post_type_archive_title('', $value));
+assertType('void', previous_posts($value));
+assertType('void', single_cat_title('', $value));
+assertType('void', single_post_title('', $value));
+assertType('void', single_tag_title('', $value));
+assertType('void', single_term_title('', $value));
+assertType('void', the_date('', '', '', $value));
+assertType('void', the_modified_date('', '', '', $value));
+assertType('void', wp_loginout('', $value));
+assertType('void', wp_register('', '', $value));
+assertType('void', wp_title('', $value));
+
+// Explicit value of false
+$value = false;
+assertType('string', comment_class('', null, null, $value));
+assertType('string', edit_term_link('', '', '', null, $value));
+assertType('string', get_calendar(true, $value));
+assertType('string', next_posts(0, $value));
+assertType('string', post_type_archive_title('', $value));
+assertType('string', previous_posts(false));
+assertType('string', single_cat_title('', $value));
+assertType('string', single_post_title('', $value));
+assertType('string', single_tag_title('', $value));
+assertType('string', single_term_title('', $value));
+assertType('string', the_date('', '', '', $value));
+assertType('string', the_modified_date('', '', '', $value));
+assertType('string', wp_loginout('', $value));
+assertType('string', wp_register('', '', $value));
+assertType('string', wp_title('', $value));
+
+// Unknown value
+$value = isset($_GET['foo']);
+assertType('string|void', comment_class('', null, null, $value));
+assertType('string|void', edit_term_link('', '', '', null, $value));
+assertType('string|void', get_calendar(true, $value));
+assertType('string|void', next_posts(0, $value));
+assertType('string|void', post_type_archive_title('', $value));
+assertType('string|void', previous_posts($value));
+assertType('string|void', single_cat_title('', $value));
+assertType('string|void', single_post_title('', $value));
+assertType('string|void', single_tag_title('', $value));
+assertType('string|void', single_term_title('', $value));
+assertType('string|void', the_date('', '', '', $value));
+assertType('string|void', the_modified_date('', '', '', $value));
+assertType('string|void', wp_loginout('', $value));
+assertType('string|void', wp_register('', '', $value));
+assertType('string|void', wp_title('', $value));


### PR DESCRIPTION
These functions are [nearly] the worst. I've seen their non-existent return values used several times.

This covers all procedural functions with an `$echo` or `$display` parameter (all of which have a default value of `true`). There are some others which support an `$echo` argument inside an `$args` array, this doesn't cover those.