### PR TITLE
Allow array like types in StringOrArrayDynamicFunctionReturnTypeExtension

### DIFF
--- a/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
+++ b/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\StringType;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\Type;
 
 class StringOrArrayDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
@@ -34,13 +35,14 @@ class StringOrArrayDynamicFunctionReturnTypeExtension implements \PHPStan\Type\D
                 $functionReflection->getVariants()
             )->getReturnType();
         }
-
         $dataArg = $args[0]->value;
         $dataArgType = $scope->getType($dataArg);
-        if ($dataArgType instanceof ArrayType) {
+        if ($dataArgType->isArray()->yes()) {
             $keyType = $dataArgType->getIterableKeyType();
-            $itemType = $dataArgType->getIterableValueType();
-            return new ArrayType($keyType, $itemType);
+            if ($keyType instanceof StringType) {
+                return new ArrayType(new StringType(), new StringType());
+            }
+            return new ArrayType(new IntegerType(), new StringType());
         }
         return new StringType();
     }

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -16,6 +16,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from $this->gatherAssertTypes(__DIR__ . '/data/apply_filters.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/echo_parameter.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/esc_sql.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_comment.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post.php');

--- a/tests/data/esc_sql.php
+++ b/tests/data/esc_sql.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use stdClass;
+
+use function PHPStan\Testing\assertType;
+
+// Indexed array as parameter
+assertType('array<int, string>', esc_sql(['someValue', 'toEscape']));
+
+// Associative array as parameter
+assertType('array<string, string>', esc_sql(['someValue' => 'toEscape']));
+
+// String as parameter
+assertType('string', esc_sql('someValueToEscape'));
+
+// Wrong type provided (esc_sql() returns an empty string in that case)
+assertType('string', esc_sql(new \stdClass()));


### PR DESCRIPTION
## Issue
Let's see a concrete example. In some cases, when calling `esc_sql($foo)`, PHPStan can interpret `$foo` as an `IntersectionType`. 
In such case, the returned value of `StringOrArrayDynamicFunctionReturnTypeExtension::getTypeFromFunctionCall()` is a `StringType` even if the provided `IntersectionType` is a mix of `ArrayType` and `NonEmptyArrayType`.
IMHO we should use `SomeType::isArray()` to check the provided argument to `esc_sql()` is indeed an array.

## Changes
- Use `isArray()` to check the argument type.
- Depending on the key type, return an associative array or an indexed array.
- Add unit tests for the `esc_sql()` function.

## To go further
Should I add some tests for `wp_slash` and `wp_unslash` too ?