### PR TITLE
Switch from boostrap stubs to scanned wordpress dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Please see [WooCommerce Stubs](https://github.com/php-stubs/woocommerce-stubs)
 ### What this extension does
 
 - Makes it possible to run PHPStan on WordPress plugins and themes
-- Loads [`php-stubs/wordpress-stubs`](https://github.com/php-stubs/wordpress-stubs) package
+- Loads [`johnpbloch/wordpress-core`](https://github.com/johnpbloch/wordpress-core) package
 - Provides dynamic return type extensions for many core functions
 - Defines some core constants
 - Handles special functions and classes e.g. `is_wp_error()`
@@ -102,12 +102,3 @@ To make the best use of this feature, ensure that the type of the first `@param`
 - If you are not bound by PHP 5 consider following
   [Neutron Standard](https://github.com/Automattic/phpcs-neutron-standard)
 - Do not enable `exit_error` in `WP_CLI::launch` or `WP_CLI::runcommand` to keep your code testable
-
-### Dirty corner (FAQ)
-
-WordPress uses conditional function and class definition for override purposes.
-Use `sed` command to exclude function stubs when they are previously defined.
-
-```bash
-sed -i -e 's#function is_gd_image#function __is_gd_image#' vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
-```

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "php-stubs/wordpress-stubs": "^4.7 || ^5.0",
-        "phpstan/phpstan": "^1.0",
-        "symfony/polyfill-php73": "^1.12.0"
+        "phpstan/phpstan": ">=1.0 <1.6",
+        "symfony/polyfill-php73": "^1.12.0",
+        "johnpbloch/wordpress-core": "^4.7 || ^5.0"
     },
     "require-dev": {
         "composer/composer": "^2.1.12",

--- a/example/.travis.yml
+++ b/example/.travis.yml
@@ -1,6 +1,3 @@
-install:
-  - |
-    if [ "$(phpenv version-name)" == 7.3 ]; then sed -i -e 's#^function is_countable(#// &#' vendor/giacocorsiglia/wordpress-stubs/wordpress-stubs.php; fi
 script:
   - |
     vendor/bin/phpstan analyze --ansi --memory-limit=1G --no-progress

--- a/extension.neon
+++ b/extension.neon
@@ -80,8 +80,9 @@ rules:
     - SzepeViktor\PHPStan\WordPress\IsWpErrorRule
 parameters:
     bootstrapFiles:
-        - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php
         - bootstrap.php
+    scanDirectories:
+        - %rootDir%/../../johnpbloch/wordpress-core
     dynamicConstantNames:
         - WP_DEBUG
         - WP_DEBUG_LOG

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,8 @@ includes:
 parameters:
     level: 9
     # WpThemeMagicPropertiesClassReflectionExtension needs WP_Theme
-    scanFiles:
-        - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
+    scanDirectories:
+        - vendor/johnpbloch/wordpress-core
     paths:
         - bootstrap.php
         - src/

--- a/tests/data/_get_list_table.php
+++ b/tests/data/_get_list_table.php
@@ -11,4 +11,4 @@ assertType('WP_Posts_List_Table|false', _get_list_table('WP_Posts_List_Table'));
 assertType('Unknown_Table|false', _get_list_table('Unknown_Table'));
 
 // Unknown class name
-assertType('\WP_List_Table|false', _get_list_table($_GET['foo']));
+assertType('WP_List_Table|false', _get_list_table($_GET['foo']));

--- a/tests/data/get_comment.php
+++ b/tests/data/get_comment.php
@@ -12,7 +12,7 @@ assertType('WP_Comment|null', get_comment(1, OBJECT));
 assertType('WP_Comment|null', get_comment(1, 'Hello'));
 
 // Unknown output
-assertType('array|\WP_Comment|null', get_comment(1, $_GET['foo']));
+assertType('array|WP_Comment|null', get_comment(1, $_GET['foo']));
 
 // Associative array output
 assertType('array<string, mixed>|null', get_comment(1, ARRAY_A));

--- a/tests/data/get_object_taxonomies.php
+++ b/tests/data/get_object_taxonomies.php
@@ -12,7 +12,7 @@ assertType('array<int, string>', get_object_taxonomies('post', 'names'));
 assertType('array<int, string>', get_object_taxonomies('post', 'Hello'));
 
 // Unknown output
-assertType('array<string|\WP_Taxonomy>', get_object_taxonomies('post', $_GET['foo']));
+assertType('array<string|WP_Taxonomy>', get_object_taxonomies('post', $_GET['foo']));
 
 // Objects output
 assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post', 'objects'));

--- a/tests/data/get_post.php
+++ b/tests/data/get_post.php
@@ -12,7 +12,7 @@ assertType('WP_Post|null', get_post(1, OBJECT));
 assertType('WP_Post|null', get_post(1, 'Hello'));
 
 // Unknown output
-assertType('array|\WP_Post|null', get_post(1, $_GET['foo']));
+assertType('array|WP_Post|null', get_post(1, $_GET['foo']));
 
 // Associative array output
 assertType('array<string, mixed>|null', get_post(1, ARRAY_A));


### PR DESCRIPTION
Closes https://github.com/szepeviktor/phpstan-wordpress/issues/99
Just playing around with an improvement idea.

had to temporarily limit the phpstan upper version for testing because currently 1.6.0 seems to be not fully compatible yet (HookDocsRuleTest).