### PR TITLE
Avoid namespace-clashing of test helpers

### DIFF
--- a/tests/HookDocsRuleTest.php
+++ b/tests/HookDocsRuleTest.php
@@ -38,43 +38,43 @@ class HookDocsRuleTest extends \PHPStan\Testing\RuleTestCase
             [
                 [
                     'Expected 2 @param tags, found 1.',
-                    22,
+                    19,
                 ],
                 [
                     'Expected 2 @param tags, found 3.',
-                    31,
+                    28,
                 ],
                 [
                     '@param string $one does not accept actual type of parameter: int|string.',
-                    43,
+                    40,
                 ],
                 [
                     '@param string $one does not accept actual type of parameter: int.',
-                    53,
+                    50,
                 ],
                 [
                     '@param tag must not be named $this. Choose a descriptive alias, for example $instance.',
-                    82,
+                    79,
                 ],
                 [
                     'Expected 2 @param tags, found 1.',
-                    97,
+                    94,
                 ],
                 [
-                    '@param ChildTestClass $one does not accept actual type of parameter: ParentTestClass.',
-                    134,
+                    '@param SzepeViktor\PHPStan\WordPress\Tests\ChildTestClass $one does not accept actual type of parameter: SzepeViktor\PHPStan\WordPress\Tests\ParentTestClass.',
+                    131,
                 ],
                 [
                     '@param string $one does not accept actual type of parameter: string|null.',
-                    155,
+                    152,
                 ],
                 [
                     'One or more @param tags has an invalid name or invalid syntax.',
-                    170,
+                    167,
                 ],
                 [
                     'One or more @param tags has an invalid name or invalid syntax.',
-                    206,
+                    203,
                 ],
             ]
         );

--- a/tests/data/apply_filters.php
+++ b/tests/data/apply_filters.php
@@ -9,7 +9,6 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 
 use function PHPStan\Testing\assertType;
 use function apply_filters;
-use function returnValue;
 
 $value = apply_filters('filter', 'Hello, World');
 assertType('mixed', $value);

--- a/tests/data/hook-docs.php
+++ b/tests/data/hook-docs.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
-use ChildTestClass;
-use ParentTestClass;
-
 // phpcs:disable Squiz.NamingConventions.ValidFunctionName.NotCamelCaps,Squiz.NamingConventions.ValidVariableName.NotCamelCaps,Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
 $one = 1;
@@ -109,7 +106,7 @@ function correct_inherited_param_type(ChildTestClass $one)
     /**
      * This param tag is for a super class of the variable, which is fine.
      *
-     * @param \ParentTestClass $one First parameter.
+     * @param ParentTestClass $one First parameter.
      */
     $args = apply_filters('filter', $one);
 }
@@ -119,7 +116,7 @@ function correct_interface_param_type(ChildTestClass $one)
     /**
      * This param tag is for the interface of the variable, which is fine.
      *
-     * @param \TestInterface $one First parameter.
+     * @param TestInterface $one First parameter.
      */
     $args = apply_filters('filter', $one);
 }
@@ -129,7 +126,7 @@ function incorrect_inherited_param_type(ParentTestClass $one)
     /**
      * This param tag is for a child class of the variable. Oh no.
      *
-     * @param \ChildTestClass $one First parameter.
+     * @param ChildTestClass $one First parameter.
      */
     $args = apply_filters('filter', $one);
 }

--- a/tests/functions.php
+++ b/tests/functions.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
 /**
  * Returns the passed value.
  *
@@ -18,10 +20,10 @@ interface TestInterface
 {
 }
 
-class ParentTestClass implements \TestInterface
+class ParentTestClass implements TestInterface
 {
 }
 
-class ChildTestClass extends \ParentTestClass
+class ChildTestClass extends ParentTestClass
 {
 }


### PR DESCRIPTION
Should help move https://github.com/szepeviktor/phpstan-wordpress/pull/98 forward, see https://github.com/szepeviktor/phpstan-wordpress/pull/98#issuecomment-1115253979