### PR TITLE
Use relative path in config file

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -84,7 +84,7 @@ rules:
     - SzepeViktor\PHPStan\WordPress\IsWpErrorRule
 parameters:
     bootstrapFiles:
-        - %rootDir%/../../php-stubs/wordpress-stubs/wordpress-stubs.php
+        - ../../php-stubs/wordpress-stubs/wordpress-stubs.php
         - bootstrap.php
     dynamicConstantNames:
         - WP_DEBUG


### PR DESCRIPTION
```
By dropping `%rootDir%` variable, including extension isn't strictly tied to path of PHPStan executable.
```

I would like to request a change in config file for this extension.

In my case, I would like to use PHPStan through `phar` file located in `tools` directory (default for installation from phive). Actually, it's possible, if I don't use `phpstan/extensions-installer` and rely on explicit include in my config file. (This also applies to globally installed phpstan executable).

Relying on relative path searches for wordpress-stubs package from current working directory instead of executable location, which is desired in aforementioned cases.