### PR TITLE
Add support for WP 6.0 stubs.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "php-stubs/wordpress-stubs": "^4.7 || ^5.0",
+        "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
         "phpstan/phpstan": "^1.6",
         "symfony/polyfill-php73": "^1.12.0"
     },


### PR DESCRIPTION
Since WordPress (and likewise `php-stubs/wordpress-stubs`) doesn't follow SemVer, I assume this one-liner is all that's necessary.