### PR TITLE
Add `WpParseUrlFunctionDynamicReturnTypeExtension`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -76,6 +76,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: SzepeViktor\PHPStan\WordPress\WpParseUrlFunctionDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\HookDocsVisitor
         tags:
             - phpstan.parser.richParserNodeVisitor

--- a/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * Set return type of wp_parse_url().
+ *
+ * Based on ParseUrlFunctionDynamicReturnTypeExtension in PHPStan itself.
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ConstantType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+use function count;
+use function parse_url;
+
+use const PHP_URL_FRAGMENT;
+use const PHP_URL_HOST;
+use const PHP_URL_PASS;
+use const PHP_URL_PATH;
+use const PHP_URL_PORT;
+use const PHP_URL_QUERY;
+use const PHP_URL_SCHEME;
+use const PHP_URL_USER;
+
+final class WpParseUrlFunctionDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+
+    /** @var array<int,Type>|null */
+    private $componentTypesPairedConstants = null;
+
+    /** @var array<string,Type>|null */
+    private $componentTypesPairedStrings = null;
+
+    /** @var Type|null */
+    private $allComponentsTogetherType = null;
+
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'wp_parse_url';
+    }
+
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    {
+        if (count($functionCall->getArgs()) < 1) {
+            return ParametersAcceptorSelector::selectSingle(
+                $functionReflection->getVariants()
+            )->getReturnType();
+        }
+
+        $this->cacheReturnTypes();
+
+        $urlType = $scope->getType($functionCall->getArgs()[0]->value);
+        if (count($functionCall->getArgs()) > 1) {
+            $componentType = $scope->getType($functionCall->getArgs()[1]->value);
+
+            if (!$componentType instanceof ConstantType) {
+                return $this->createAllComponentsReturnType();
+            }
+
+            $componentType = $componentType->toInteger();
+
+            if (!$componentType instanceof ConstantIntegerType) {
+                throw new \PHPStan\ShouldNotHappenException();
+            }
+        } else {
+            $componentType = new ConstantIntegerType(-1);
+        }
+
+        if ($urlType instanceof ConstantStringType) {
+            try {
+                $result = @parse_url($urlType->getValue(), $componentType->getValue());
+            } catch (\ValueError $e) {
+                return new ConstantBooleanType(false);
+            }
+
+            return $scope->getTypeFromValue($result);
+        }
+
+        if ($componentType->getValue() === -1) {
+            return $this->createAllComponentsReturnType();
+        }
+
+        return $this->componentTypesPairedConstants[$componentType->getValue()] ?? new ConstantBooleanType(false);
+    }
+
+    private function createAllComponentsReturnType(): Type
+    {
+        if ($this->allComponentsTogetherType === null) {
+            $returnTypes = [
+                new ConstantBooleanType(false),
+            ];
+
+            $builder = ConstantArrayTypeBuilder::createEmpty();
+
+            if ($this->componentTypesPairedStrings === null) {
+                throw new \PHPStan\ShouldNotHappenException();
+            }
+
+            foreach ($this->componentTypesPairedStrings as $componentName => $componentValueType) {
+                $builder->setOffsetValueType(new ConstantStringType($componentName), $componentValueType, true);
+            }
+
+            $returnTypes[] = $builder->getArray();
+
+            $this->allComponentsTogetherType = TypeCombinator::union(...$returnTypes);
+        }
+
+        return $this->allComponentsTogetherType;
+    }
+
+    private function cacheReturnTypes(): void
+    {
+        if ($this->componentTypesPairedConstants !== null) {
+            return;
+        }
+
+        $string = new StringType();
+        $integer = new IntegerType();
+        $false = new ConstantBooleanType(false);
+        $null = new NullType();
+
+        $stringOrFalseOrNull = TypeCombinator::union($string, $false, $null);
+        $integerOrFalseOrNull = TypeCombinator::union($integer, $false, $null);
+
+        $this->componentTypesPairedConstants = [
+            PHP_URL_SCHEME => $stringOrFalseOrNull,
+            PHP_URL_HOST => $stringOrFalseOrNull,
+            PHP_URL_PORT => $integerOrFalseOrNull,
+            PHP_URL_USER => $stringOrFalseOrNull,
+            PHP_URL_PASS => $stringOrFalseOrNull,
+            PHP_URL_PATH => $stringOrFalseOrNull,
+            PHP_URL_QUERY => $stringOrFalseOrNull,
+            PHP_URL_FRAGMENT => $stringOrFalseOrNull,
+        ];
+
+        $this->componentTypesPairedStrings = [
+            'scheme' => $string,
+            'host' => $string,
+            'port' => $integer,
+            'user' => $string,
+            'pass' => $string,
+            'path' => $string,
+            'query' => $string,
+            'fragment' => $string,
+        ];
+    }
+
+}

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -26,6 +26,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from $this->gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_parse_url.php');
     }
 
     /**

--- a/tests/data/wp_parse_url.php
+++ b/tests/data/wp_parse_url.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Test data for WpParseUrlFunctionDynamicReturnTypeExtension.
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function PHPStan\Testing\assertType;
+use function wp_clear_scheduled_hook;
+use function wp_insert_attachment;
+use function wp_insert_category;
+use function wp_insert_link;
+use function wp_insert_post;
+use function wp_reschedule_event;
+use function wp_schedule_event;
+use function wp_schedule_single_event;
+use function wp_set_comment_status;
+use function wp_unschedule_event;
+use function wp_unschedule_hook;
+use function wp_update_comment;
+use function wp_update_post;
+
+/** @var int $integer */
+$integer = doFoo();
+
+/** @var string $string */
+$string = doFoo();
+
+/**
+ * wp_parse_url()
+ */
+$value = wp_parse_url();
+assertType('mixed', $value);
+
+$value = wp_parse_url('http://abc.def');
+assertType("array{scheme: 'http', host: 'abc.def'}", $value);
+
+$value = wp_parse_url('http://def.abc', -1);
+assertType("array{scheme: 'http', host: 'def.abc'}", $value);
+
+$value = wp_parse_url('http://def.abc', $integer);
+assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $value);
+
+$value = wp_parse_url('http://def.abc', PHP_URL_FRAGMENT);
+assertType('null', $value);
+
+$value = wp_parse_url('http://def.abc#this-is-fragment', PHP_URL_FRAGMENT);
+assertType("'this-is-fragment'", $value);
+
+$value = wp_parse_url('http://def.abc#this-is-fragment', 9999);
+assertType('false', $value);
+
+$value = wp_parse_url($string, 9999);
+assertType('false', $value);
+
+$value = wp_parse_url($string, PHP_URL_PORT);
+assertType('int|false|null', $value);
+
+$value = wp_parse_url($string);
+assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $value);


### PR DESCRIPTION
I noticed that PHPStan has a custom extension to handle `parse_url()` return types, but no such extension exists for `wp_parse_url()`.

This PR straight up copies `ParseUrlFunctionDynamicReturnTypeExtension` from PHPStan so one gets more accurate types for `wp_parse_url()` than just "mixed"