### PR TITLE
Improve dynamic return type extension for get_post()

### DIFF
--- a/src/GetPostDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostDynamicFunctionReturnTypeExtension.php
@@ -52,7 +52,9 @@ class GetPostDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynamic
             // When called with an $output that isn't a constant string, return default return type
             if (! $scope->getType($args[1]->value) instanceof ConstantStringType) {
                 return TypeCombinator::union(
-                    $objectType, $associativeArrayType, $numericArrayType
+                    $objectType,
+                    $associativeArrayType,
+                    $numericArrayType
                 );
             }
             if ($args[1]->value instanceof ConstFetch) {

--- a/tests/data/get_post.php
+++ b/tests/data/get_post.php
@@ -6,16 +6,29 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 
 use function PHPStan\Testing\assertType;
 
+/** @var \WP_Post $wpPostType */
+$wpPostType = new \stdClass();
+
 // Default output
+assertType('WP_Post|null', get_post());
 assertType('WP_Post|null', get_post(1));
 assertType('WP_Post|null', get_post(1, OBJECT));
-assertType('WP_Post|null', get_post(1, 'Hello'));
-
-// Unknown output
-assertType('array|\WP_Post|null', get_post(1, $_GET['foo']));
+assertType('WP_Post|null', get_post(1, $_GET['foo']));
+assertType('WP_Post', get_post($wpPostType));
+assertType('WP_Post', get_post($wpPostType, OBJECT));
+assertType('WP_Post', get_post($wpPostType, $_GET['foo']));
+assertType('WP_Post|null', get_page_by_path('page/path'));
+assertType('WP_Post|null', get_page_by_path('page/path', OBJECT));
+assertType('WP_Post|null', get_page_by_path('page/path', $_GET['foo']));
 
 // Associative array output
+assertType('array<string, mixed>|null', get_post(null, ARRAY_A));
 assertType('array<string, mixed>|null', get_post(1, ARRAY_A));
+assertType('array<string, mixed>', get_post($wpPostType, ARRAY_A));
+assertType('array<string, mixed>|null', get_page_by_path('page/path', ARRAY_A));
 
 // Numeric array output
+assertType('array<int, mixed>|null', get_post(null, ARRAY_N));
 assertType('array<int, mixed>|null', get_post(1, ARRAY_N));
+assertType('array<int, mixed>', get_post($wpPostType, ARRAY_N));
+assertType('array<int, mixed>|null', get_page_by_path('page/path', ARRAY_N));

--- a/tests/data/get_post.php
+++ b/tests/data/get_post.php
@@ -16,7 +16,7 @@ assertType('WP_Post|null', get_post(1, OBJECT));
 assertType('array<int|string, mixed>|WP_Post|null', get_post(1, $_GET['foo']));
 assertType('WP_Post', get_post($wpPostType));
 assertType('WP_Post', get_post($wpPostType, OBJECT));
-assertType('array<int|string, mixed>|WP_Post|null', get_post($wpPostType, $_GET['foo']));
+assertType('array<int|string, mixed>|WP_Post', get_post($wpPostType, $_GET['foo']));
 assertType('WP_Post|null', get_page_by_path('page/path'));
 assertType('WP_Post|null', get_page_by_path('page/path', OBJECT));
 assertType('array<int|string, mixed>|WP_Post|null', get_page_by_path('page/path', $_GET['foo']));

--- a/tests/data/get_post.php
+++ b/tests/data/get_post.php
@@ -13,13 +13,13 @@ $wpPostType = new \stdClass();
 assertType('WP_Post|null', get_post());
 assertType('WP_Post|null', get_post(1));
 assertType('WP_Post|null', get_post(1, OBJECT));
-assertType('WP_Post|null', get_post(1, $_GET['foo']));
+assertType('array<int|string, mixed>|WP_Post|null', get_post(1, $_GET['foo']));
 assertType('WP_Post', get_post($wpPostType));
 assertType('WP_Post', get_post($wpPostType, OBJECT));
-assertType('WP_Post', get_post($wpPostType, $_GET['foo']));
+assertType('array<int|string, mixed>|WP_Post|null', get_post($wpPostType, $_GET['foo']));
 assertType('WP_Post|null', get_page_by_path('page/path'));
 assertType('WP_Post|null', get_page_by_path('page/path', OBJECT));
-assertType('WP_Post|null', get_page_by_path('page/path', $_GET['foo']));
+assertType('array<int|string, mixed>|WP_Post|null', get_page_by_path('page/path', $_GET['foo']));
 
 // Associative array output
 assertType('array<string, mixed>|null', get_post(null, ARRAY_A));


### PR DESCRIPTION
This PR improves the dynamic return type extension for `get_post()` and `get_page_by_path()` by
1. removing `null` if the first argument `$post` is of type `WP_Post`,
2. dropping to return the default type hints in favor of always returning `WP_Post|null` as long as the second argument `$output` is not `ARRAY_A` or `ARRAY_N`.

Reasoning:

1. If `$post` is an instance of `WP_Post` the variable `_post` is set to `$post` (see [here](https://github.com/WordPress/WordPress/blob/87464289c387757943d07e8474d8dab61ba7b6f2/wp-includes/post.php#L995-L997)) and will never fail the existence check (see [here](https://github.com/WordPress/WordPress/blob/87464289c387757943d07e8474d8dab61ba7b6f2/wp-includes/post.php#L1010-L1012)) and hence will never be of type `null`.
2. Both `get_post()` and `get_page_by_path()` only check `$output` against `ARRAY_A` and `ARRAY_N`. If `$output` is set to something different `get_post()` and `get_page_by_path()` will always return an instance of `WP_Post` or `null` irrespective of the type and the value of `$output` (see [here](https://github.com/WordPress/WordPress/blob/87464289c387757943d07e8474d8dab61ba7b6f2/wp-includes/post.php#L1016-L1022)). Hence there's also no need to type check `$output`.
