### PR TITLE
Use `::class` to get the fully qualified name of the class

### DIFF
--- a/src/WpThemeGetDynamicMethodReturnTypeExtension.php
+++ b/src/WpThemeGetDynamicMethodReturnTypeExtension.php
@@ -46,7 +46,7 @@ class WpThemeGetDynamicMethodReturnTypeExtension implements \PHPStan\Type\Dynami
 
     public function getClass(): string
     {
-        return '\WP_Theme';
+        return \WP_Theme::class;
     }
 
     public function isMethodSupported(MethodReflection $methodReflection): bool


### PR DESCRIPTION
From PHPStan 1.8.6 `return '\WP_Theme';` no longer works. PHPStan skips the dynamic return type when analyzing an instance of `WP_Theme`.