### PR TITLE
Fix FQCN types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
-        "phpstan/phpstan": "^1.6",
+        "phpstan/phpstan": "^1.8.7",
         "symfony/polyfill-php73": "^1.12.0"
     },
     "require-dev": {

--- a/src/WpThemeGetDynamicMethodReturnTypeExtension.php
+++ b/src/WpThemeGetDynamicMethodReturnTypeExtension.php
@@ -46,7 +46,7 @@ class WpThemeGetDynamicMethodReturnTypeExtension implements \PHPStan\Type\Dynami
 
     public function getClass(): string
     {
-        return '\WP_Theme';
+        return 'WP_Theme';
     }
 
     public function isMethodSupported(MethodReflection $methodReflection): bool

--- a/tests/data/_get_list_table.php
+++ b/tests/data/_get_list_table.php
@@ -11,4 +11,4 @@ assertType('WP_Posts_List_Table|false', _get_list_table('WP_Posts_List_Table'));
 assertType('Unknown_Table|false', _get_list_table('Unknown_Table'));
 
 // Unknown class name
-assertType('\WP_List_Table|false', _get_list_table($_GET['foo']));
+assertType('WP_List_Table|false', _get_list_table($_GET['foo']));

--- a/tests/data/get_comment.php
+++ b/tests/data/get_comment.php
@@ -12,7 +12,7 @@ assertType('WP_Comment|null', get_comment(1, OBJECT));
 assertType('WP_Comment|null', get_comment(1, 'Hello'));
 
 // Unknown output
-assertType('array|\WP_Comment|null', get_comment(1, $_GET['foo']));
+assertType('array|WP_Comment|null', get_comment(1, $_GET['foo']));
 
 // Associative array output
 assertType('array<string, mixed>|null', get_comment(1, ARRAY_A));

--- a/tests/data/get_object_taxonomies.php
+++ b/tests/data/get_object_taxonomies.php
@@ -12,7 +12,7 @@ assertType('array<int, string>', get_object_taxonomies('post', 'names'));
 assertType('array<int, string>', get_object_taxonomies('post', 'Hello'));
 
 // Unknown output
-assertType('array<string|\WP_Taxonomy>', get_object_taxonomies('post', $_GET['foo']));
+assertType('array<string|WP_Taxonomy>', get_object_taxonomies('post', $_GET['foo']));
 
 // Objects output
 assertType('array<string, WP_Taxonomy>', get_object_taxonomies('post', 'objects'));


### PR DESCRIPTION
Fixes the FQCN types by requiring PHPStan 1.8.7 where the behaviour was fixed causing a BC break here.

Refs: https://github.com/phpstan/phpstan/issues/8118
> Likely an **expected** side effect of this change https://github.com/phpstan/phpstan-src/pull/1758

Also if you check the changed tests files - each of them has other assertions where the backslash was missing, so this was already inconsistent and this is the best way to "fix" it here and move forward IMO.