### PR TITLE
Fix AssertWpErrorTypeSpecifying extensions

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,6 +6,7 @@
 
     <exclude-pattern>tests/data/*</exclude-pattern>
     <exclude-pattern>tests/functions.php</exclude-pattern>
+    <exclude-pattern>tests/WP_UnitTestCase_Base.php</exclude-pattern>
 
     <rule ref="PSR12NeutronRuleset">
         <exclude name="Generic.Files.LineLength"/>
@@ -15,6 +16,7 @@
 
     <!-- PHPCS does not understand yield -->
     <rule ref="NeutronStandard.Functions.TypeHint.UnusedReturnType">
+        <exclude-pattern>tests/AssertMethodTypeSpecifyingExtensionTest.php</exclude-pattern>
         <exclude-pattern>tests/DynamicReturnTypeExtensionTest.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/AssertNotWpErrorTypeSpecifyingExtension.php
+++ b/src/AssertNotWpErrorTypeSpecifyingExtension.php
@@ -29,23 +29,19 @@ class AssertNotWpErrorTypeSpecifyingExtension implements \PHPStan\Type\MethodTyp
 
     public function isMethodSupported(MethodReflection $methodReflection, MethodCall $node, TypeSpecifierContext $context): bool
     {
-        return strtolower($methodReflection->getName()) === 'assertNotWPError'
+        return strtolower($methodReflection->getName()) === 'assertnotwperror'
             && isset($node->args[0])
-            && !$context->null();
+            && $context->null();
     }
 
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public function specifyTypes(MethodReflection $methodReflection, MethodCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        if ($context->null()) {
-            throw new \PHPStan\ShouldNotHappenException();
-        }
-
         $expr = $node->getArgs()[0]->value;
         $typeBefore = $scope->getType($expr);
         $type = TypeCombinator::remove($typeBefore, new ObjectType('WP_Error'));
 
-        return $this->typeSpecifier->create($expr, $type, $context);
+        return $this->typeSpecifier->create($expr, $type, TypeSpecifierContext::createTruthy());
     }
 
     public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/src/AssertWpErrorTypeSpecifyingExtension.php
+++ b/src/AssertWpErrorTypeSpecifyingExtension.php
@@ -28,21 +28,17 @@ class AssertWpErrorTypeSpecifyingExtension implements \PHPStan\Type\MethodTypeSp
 
     public function isMethodSupported(MethodReflection $methodReflection, MethodCall $node, TypeSpecifierContext $context): bool
     {
-        return strtolower($methodReflection->getName()) === 'assertWPError'
+        return strtolower($methodReflection->getName()) === 'assertwperror'
             && isset($node->args[0])
-            && !$context->null();
+            && $context->null();
     }
 
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public function specifyTypes(MethodReflection $methodReflection, MethodCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        if ($context->null()) {
-            throw new \PHPStan\ShouldNotHappenException();
-        }
-
         $args = $node->getArgs();
 
-        return $this->typeSpecifier->create($args[0]->value, new ObjectType('WP_Error'), $context);
+        return $this->typeSpecifier->create($args[0]->value, new ObjectType('WP_Error'), TypeSpecifierContext::createTruthy());
     }
 
     public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void

--- a/tests/WP_UnitTestCase_Base.php
+++ b/tests/WP_UnitTestCase_Base.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+class WP_UnitTestCase_Base extends TestCase
+{
+    /**
+     * Asserts that the given value is an instance of WP_Error.
+     *
+     * @param mixed  $actual  The value to check.
+     * @param string $message Optional. Message to display when the assertion fails.
+     * @return void
+     */
+    public function assertWPError( $actual, $message = '' ) {
+    }
+
+    /**
+     * Asserts that the given value is not an instance of WP_Error.
+     *
+     * @param mixed  $actual  The value to check.
+     * @param string $message Optional. Message to display when the assertion fails.
+     * @return void
+     */
+    public function assertNotWPError( $actual, $message = '' ) {
+    }
+}

--- a/tests/data/assert_not_wp_error.php
+++ b/tests/data/assert_not_wp_error.php
@@ -13,7 +13,7 @@ class AssertNotWpError
     public function inheritedAssertMethodsNarrowType(): void
     {
         /** @var \WP_Error|int $no */
-        $no = $no;
+        $no = $_GET['no'];
 
         $customAsserter = new class () extends WP_UnitTestCase_Base {};
         $customAsserter->assertNotWPError($no);

--- a/tests/data/assert_not_wp_error.php
+++ b/tests/data/assert_not_wp_error.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
+use WP_UnitTestCase_Base;
 use function PHPStan\Testing\assertType;
 
-class Foo
+class AssertNotWpError
 {
 
     public function inheritedAssertMethodsNarrowType(): void

--- a/tests/data/assert_wp_error.php
+++ b/tests/data/assert_wp_error.php
@@ -7,23 +7,16 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 use WP_UnitTestCase_Base;
 use function PHPStan\Testing\assertType;
 
-class Foo {
-    public function foo($foo) {
-
-    }
-};
-
 class AssertWpError
 {
 
     public function inheritedAssertMethodsNarrowType(): void
     {
         /** @var \WP_Error|int $yes */
-        $yes = $yes;
+        $yes = $_GET['yes'];
 
         $customAsserter = new class () extends WP_UnitTestCase_Base {};
         $customAsserter->assertWPError($yes);
-        (new Foo())->foo($yes);
         assertType('WP_Error', $yes);
     }
 

--- a/tests/data/assert_wp_error.php
+++ b/tests/data/assert_wp_error.php
@@ -4,9 +4,16 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
+use WP_UnitTestCase_Base;
 use function PHPStan\Testing\assertType;
 
-class Foo
+class Foo {
+    public function foo($foo) {
+
+    }
+};
+
+class AssertWpError
 {
 
     public function inheritedAssertMethodsNarrowType(): void
@@ -16,6 +23,7 @@ class Foo
 
         $customAsserter = new class () extends WP_UnitTestCase_Base {};
         $customAsserter->assertWPError($yes);
+        (new Foo())->foo($yes);
         assertType('WP_Error', $yes);
     }
 


### PR DESCRIPTION
Viktor you were right, this was autoloader related. PHPStan needs to be able to cleanly autoload this class in order to fire the extensions. This is my first hacky approach to fix that autoloading with some kind of stub class copied into the tests folder.

The rest are just tiny fixes for the extensions themselves.

Refs: https://github.com/szepeviktor/phpstan-wordpress/pull/124 CC @swissspidy 