### PR TITLE
Increase the memory limit during unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "test:cs": "phpcs",
         "test:cs:fix": "phpcbf",
         "test:phpstan": "phpstan analyze",
-        "test:phpunit": "phpunit",
+        "test:phpunit": "phpunit -d memory_limit=1G",
         "test:syntax": "parallel-lint bootstrap.php src/ tests/"
     }
 }


### PR DESCRIPTION
Running `composer test:phpunit` locally results in an out of memory error hidden behind the mysterious `255` error code from PHPUnit. This fixes that by bumping the limit to 1G.

Yes the underlying memory usage should be fixed, no I don't have time to look into it at the moment.

cc @swissspidy 