### PR TITLE
Hook callback false positives for `mixed` return type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "test:cs": "phpcs",
         "test:cs:fix": "phpcbf",
         "test:phpstan": "phpstan analyze",
-        "test:phpunit": "phpunit -d memory_limit=1G",
+        "test:phpunit": "phpunit",
         "test:syntax": "parallel-lint bootstrap.php src/ tests/"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "test:cs": "phpcs",
         "test:cs:fix": "phpcbf",
         "test:phpstan": "phpstan analyze",
-        "test:phpunit": "phpunit",
+        "test:phpunit": "phpunit -d memory_limit=1G",
         "test:syntax": "parallel-lint bootstrap.php src/ tests/"
     }
 }

--- a/src/HookCallbackRule.php
+++ b/src/HookCallbackRule.php
@@ -17,6 +17,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\Constant\ConstantIntegerType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
 
@@ -205,9 +206,12 @@ class HookCallbackRule implements \PHPStan\Rules\Rule
     protected function validateFilterReturnType(ParametersAcceptor $callbackAcceptor): void
     {
         $returnType = $callbackAcceptor->getReturnType();
-        $isVoidSuperType = $returnType->isSuperTypeOf(new VoidType());
 
-        if (! $isVoidSuperType->yes()) {
+        if ($returnType instanceof MixedType && $returnType->isExplicitMixed()) {
+            return;
+        }
+
+        if (! $returnType->isSuperTypeOf(new VoidType())->yes()) {
             return;
         }
 

--- a/src/HookCallbackRule.php
+++ b/src/HookCallbackRule.php
@@ -185,22 +185,26 @@ class HookCallbackRule implements \PHPStan\Rules\Rule
     protected function validateActionReturnType(ParametersAcceptor $callbackAcceptor): void
     {
         $acceptedType = $callbackAcceptor->getReturnType();
+        $exception = new \SzepeViktor\PHPStan\WordPress\HookCallbackException(
+            sprintf(
+                'Action callback returns %s but should not return anything.',
+                $acceptedType->describe(VerbosityLevel::getRecommendedLevelByType($acceptedType))
+            )
+        );
+
+        if ($acceptedType instanceof MixedType && $acceptedType->isExplicitMixed()) {
+            throw $exception;
+        }
+
         $accepted = $this->ruleLevelHelper->accepts(
             new VoidType(),
             $acceptedType,
             true
         );
 
-        if ($accepted) {
-            return;
+        if (! $accepted) {
+            throw $exception;
         }
-
-        throw new \SzepeViktor\PHPStan\WordPress\HookCallbackException(
-            sprintf(
-                'Action callback returns %s but should not return anything.',
-                $acceptedType->describe(VerbosityLevel::getRecommendedLevelByType($acceptedType))
-            )
-        );
     }
 
     protected function validateFilterReturnType(ParametersAcceptor $callbackAcceptor): void

--- a/src/HookCallbackRule.php
+++ b/src/HookCallbackRule.php
@@ -211,11 +211,17 @@ class HookCallbackRule implements \PHPStan\Rules\Rule
     {
         $returnType = $callbackAcceptor->getReturnType();
 
-        if ($returnType instanceof MixedType && $returnType->isExplicitMixed()) {
+        if ($returnType instanceof MixedType) {
             return;
         }
 
-        if (! $returnType->isSuperTypeOf(new VoidType())->yes()) {
+        $accepted = $this->ruleLevelHelper->accepts(
+            new VoidType(),
+            $returnType,
+            true
+        );
+
+        if (! $accepted) {
             return;
         }
 

--- a/tests/HookCallbackRuleTest.php
+++ b/tests/HookCallbackRuleTest.php
@@ -120,10 +120,6 @@ class HookCallbackRuleTest extends \PHPStan\Testing\RuleTestCase
                     'Action callback returns mixed but should not return anything.',
                     102,
                 ],
-                [
-                    'Action callback returns mixed but should not return anything.',
-                    105,
-                ],
             ]
         );
     }

--- a/tests/HookCallbackRuleTest.php
+++ b/tests/HookCallbackRuleTest.php
@@ -113,12 +113,8 @@ class HookCallbackRuleTest extends \PHPStan\Testing\RuleTestCase
                     96,
                 ],
                 [
-                    'Filter callback return statement is missing.',
-                    99,
-                ],
-                [
                     'Action callback returns mixed but should not return anything.',
-                    102,
+                    99,
                 ],
             ]
         );

--- a/tests/HookCallbackRuleTest.php
+++ b/tests/HookCallbackRuleTest.php
@@ -120,6 +120,10 @@ class HookCallbackRuleTest extends \PHPStan\Testing\RuleTestCase
                     'Action callback returns mixed but should not return anything.',
                     102,
                 ],
+                [
+                    'Action callback returns mixed but should not return anything.',
+                    105,
+                ],
             ]
         );
     }

--- a/tests/HookCallbackRuleTest.php
+++ b/tests/HookCallbackRuleTest.php
@@ -116,6 +116,10 @@ class HookCallbackRuleTest extends \PHPStan\Testing\RuleTestCase
                     'Filter callback return statement is missing.',
                     99,
                 ],
+                [
+                    'Action callback returns mixed but should not return anything.',
+                    102,
+                ],
             ]
         );
     }

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -95,9 +95,6 @@ add_filter('filter', '__return_false', 10, 2);
 // Action callback returns false but should not return anything (with incorrect number of accepted args).
 add_action('action', '__return_false', 10, 2);
 
-// Filter callback return statement is missing.
-add_filter('filter', __NAMESPACE__ . '\\no_return_value_untyped');
-
 // Action callback returns mixed but should not return anything.
 add_action('action', __NAMESPACE__ . '\\return_value_mixed');
 
@@ -148,7 +145,7 @@ add_filter('filter', function(array $classes): array {
 
 // Callback function with no declared return type.
 add_action('action', __NAMESPACE__ . '\\return_value_untyped');
-add_action('action', __NAMESPACE__ . '\\return_value_implicit_mixed');
+add_filter('filter', __NAMESPACE__ . '\\no_return_value_untyped');
 
 /**
  * Correct usage:
@@ -219,7 +216,7 @@ add_action('action', function($result) {
 // Various callback types
 add_filter('filter', '__return_false');
 add_filter('filter', __NAMESPACE__ . '\\return_value_mixed');
-add_filter('filter', __NAMESPACE__ . '\\return_value_implicit_mixed');
+add_filter('filter', __NAMESPACE__ . '\\return_value_untyped');
 add_filter('filter', __NAMESPACE__ . '\\return_value_mixed_union');
 add_filter('filter', __NAMESPACE__ . '\\return_value_documented');
 add_filter('filter', __NAMESPACE__ . '\\return_value_untyped');
@@ -254,10 +251,6 @@ function no_return_value_untyped( $value ) {}
  */
 function return_value_mixed() {
     return 123;
-}
-
-function return_value_implicit_mixed( $value ) {
-    return $value;
 }
 
 /**

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -99,7 +99,7 @@ add_action('action', '__return_false', 10, 2);
 add_filter('filter', __NAMESPACE__ . '\\no_return_value_untyped');
 
 // Action callback returns mixed but should not return anything.
-add_action('action', __NAMESPACE__ . 'return_value_mixed');
+add_action('action', __NAMESPACE__ . '\\return_value_mixed');
 
 /**
  * Incorrect usage that's handled by PHPStan:

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -265,6 +265,8 @@ function return_value_implicit_mixed( $value ) {
 /**
  * Return type documented as a union that includes mixed.
  *
+ * This is added as a regression test for a bug.
+ *
  * @return int|mixed
  */
 function return_value_mixed_union() {

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -101,6 +101,9 @@ add_filter('filter', __NAMESPACE__ . '\\no_return_value_untyped');
 // Action callback returns mixed but should not return anything.
 add_action('action', __NAMESPACE__ . '\\return_value_mixed');
 
+// Action callback returns mixed but should not return anything.
+add_action('action', __NAMESPACE__ . '\\return_value_implicit_mixed');
+
 /**
  * Incorrect usage that's handled by PHPStan:
  *

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -98,6 +98,9 @@ add_action('action', '__return_false', 10, 2);
 // Filter callback return statement is missing.
 add_filter('filter', __NAMESPACE__ . '\\no_return_value_untyped');
 
+// Action callback returns mixed but should not return anything.
+add_action('action', __NAMESPACE__ . 'return_value_mixed');
+
 /**
  * Incorrect usage that's handled by PHPStan:
  *
@@ -214,6 +217,7 @@ add_action('action', function($result) {
 
 // Various callback types
 add_filter('filter', '__return_false');
+add_filter('filter', __NAMESPACE__ . '\\return_value_mixed');
 add_filter('filter', __NAMESPACE__ . '\\return_value_mixed_union');
 add_filter('filter', __NAMESPACE__ . '\\return_value_documented');
 add_filter('filter', __NAMESPACE__ . '\\return_value_untyped');
@@ -242,6 +246,13 @@ function return_value_typed() : int {
 }
 
 function no_return_value_untyped( $value ) {}
+
+/**
+ * @return mixed
+ */
+function return_value_mixed() {
+    return 123;
+}
 
 /**
  * Return type documented as a union that includes mixed.

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -214,6 +214,9 @@ add_action('action', function($result) {
 
 // Various callback types
 add_filter('filter', '__return_false');
+add_filter('filter', __NAMESPACE__ . '\\return_value_mixed_union');
+add_filter('filter', __NAMESPACE__ . '\\return_value_documented');
+add_filter('filter', __NAMESPACE__ . '\\return_value_untyped');
 add_filter('filter', __NAMESPACE__ . '\\return_value_typed');
 add_filter('filter', new TestInvokableTyped(), 10, 2);
 add_filter('filter', [new TestClassTyped, 'foo']);
@@ -239,6 +242,22 @@ function return_value_typed() : int {
 }
 
 function no_return_value_untyped( $value ) {}
+
+/**
+ * Return type documented as a union that includes mixed.
+ *
+ * @return int|mixed
+ */
+function return_value_mixed_union() {
+    return 123;
+}
+
+/**
+ * @return int
+ */
+function return_value_documented() {
+    return 123;
+}
 
 function return_value_untyped() {
     return 123;

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -218,6 +218,7 @@ add_action('action', function($result) {
 // Various callback types
 add_filter('filter', '__return_false');
 add_filter('filter', __NAMESPACE__ . '\\return_value_mixed');
+add_filter('filter', __NAMESPACE__ . '\\return_value_implicit_mixed');
 add_filter('filter', __NAMESPACE__ . '\\return_value_mixed_union');
 add_filter('filter', __NAMESPACE__ . '\\return_value_documented');
 add_filter('filter', __NAMESPACE__ . '\\return_value_untyped');
@@ -252,6 +253,10 @@ function no_return_value_untyped( $value ) {}
  */
 function return_value_mixed() {
     return 123;
+}
+
+function return_value_implicit_mixed( $value ) {
+    return $value;
 }
 
 /**

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -101,9 +101,6 @@ add_filter('filter', __NAMESPACE__ . '\\no_return_value_untyped');
 // Action callback returns mixed but should not return anything.
 add_action('action', __NAMESPACE__ . '\\return_value_mixed');
 
-// Action callback returns mixed but should not return anything.
-add_action('action', __NAMESPACE__ . '\\return_value_implicit_mixed');
-
 /**
  * Incorrect usage that's handled by PHPStan:
  *
@@ -151,6 +148,7 @@ add_filter('filter', function(array $classes): array {
 
 // Callback function with no declared return type.
 add_action('action', __NAMESPACE__ . '\\return_value_untyped');
+add_action('action', __NAMESPACE__ . '\\return_value_implicit_mixed');
 
 /**
  * Correct usage:


### PR DESCRIPTION
Fixes #125

Seems the problem is ultimately down to `mixed` return types.