### PR TITLE
Fix mixed return type for filter callbacks

### DIFF
--- a/src/HookCallbackRule.php
+++ b/src/HookCallbackRule.php
@@ -19,6 +19,7 @@ use PHPStan\Rules\RuleLevelHelper;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\VerbosityLevel;
 use PHPStan\Type\VoidType;
+use PHPStan\Type\MixedType;
 
 /**
  * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\FuncCall>
@@ -206,8 +207,9 @@ class HookCallbackRule implements \PHPStan\Rules\Rule
     {
         $returnType = $callbackAcceptor->getReturnType();
         $isVoidSuperType = $returnType->isSuperTypeOf(new VoidType());
+        $isMixedType = $returnType->equals(new MixedType());
 
-        if (! $isVoidSuperType->yes()) {
+        if ($isMixedType || $isVoidSuperType->no()) {
             return;
         }
 

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -185,6 +185,7 @@ add_filter('filter', function($value = null) {
 add_filter('filter', function($one = null, $two = null, $three = null) {
     return 123;
 });
+add_filter('filter', 'return_mixed');
 
 // Action callbacks must return void
 add_action('action', function() {
@@ -246,6 +247,10 @@ function return_value_untyped() {
 
 function filter_variadic_typed( $one, ...$two ) : int {
     return 123;
+}
+
+function return_mixed($value) : mixed {
+    return $value;
 }
 
 class TestInvokableTyped {


### PR DESCRIPTION
## Issue:
I get the following error for a filter callback with a mixed return type:
```
Filter callback return statement is missing.
```

This occurs with a callback like this:
```php
/**
 * Does things.
 *
 * @param mixed  $param  Some value.
 * @return mixed
 */
function do_things( $param ) {
    // Do things
    return $param
}
```

IMHO this is due to this [line](https://github.com/szepeviktor/phpstan-wordpress/blob/e1503589f0a0ed4950c467558d99fbad108a21ca/src/HookCallbackRule.php#L208) where we get `MixedType` which seems to be a super type of `VoidType` (maybe because it include `NullType`.

## Proposal:
- Add a special case for `MixedType`.
- Add a test for a callback with mixed return type.