### PR TITLE
Simplify returning default return type everywhere

### DIFF
--- a/src/CurrentTimeDynamicFunctionReturnTypeExtension.php
+++ b/src/CurrentTimeDynamicFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
@@ -27,18 +26,15 @@ class CurrentTimeDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyn
     /**
      * @see https://developer.wordpress.org/reference/functions/current_time/
      */
-    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         $args = $functionCall->getArgs();
         $argumentType = $scope->getType($args[0]->value);
 
         // When called with a $type that isn't a constant string, return default return type
         if (! $argumentType instanceof ConstantStringType) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $args,
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return null;
         }
 
         // Called with a constant string $type

--- a/src/GetCommentDynamicFunctionReturnTypeExtension.php
+++ b/src/GetCommentDynamicFunctionReturnTypeExtension.php
@@ -12,7 +12,6 @@ use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\StringType;
@@ -31,21 +30,15 @@ class GetCommentDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
     }
 
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
-    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         $output = 'OBJECT';
         $args = $functionCall->getArgs();
 
         if (count($args) >= 2) {
-            $argumentType = $scope->getType($args[1]->value);
-
             // When called with an $output that isn't a constant string, return default return type
-            if (! $argumentType instanceof ConstantStringType) {
-                return ParametersAcceptorSelector::selectFromArgs(
-                    $scope,
-                    $args,
-                    $functionReflection->getVariants()
-                )->getReturnType();
+            if (! $scope->getType($args[1]->value) instanceof ConstantStringType) {
+                return null;
             }
         }
 

--- a/src/GetListTableDynamicFunctionReturnTypeExtension.php
+++ b/src/GetListTableDynamicFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Constant\ConstantBooleanType;
@@ -26,7 +25,7 @@ class GetListTableDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
     }
 
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
-    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         $args = $functionCall->getArgs();
 
@@ -39,11 +38,7 @@ class GetListTableDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
 
         // When called with a $class that isn't a constant string, return default return type
         if (! $argumentType instanceof ConstantStringType) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $args,
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return null;
         }
 
         return TypeCombinator::union(

--- a/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetObjectTaxonomiesDynamicFunctionReturnTypeExtension.php
@@ -13,7 +13,6 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
@@ -31,7 +30,8 @@ class GetObjectTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\
     /**
      * @see https://developer.wordpress.org/reference/functions/get_object_taxonomies/
      */
-    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         $args = $functionCall->getArgs();
 
@@ -44,11 +44,7 @@ class GetObjectTaxonomiesDynamicFunctionReturnTypeExtension implements \PHPStan\
 
         // When called with an $output that isn't a constant string, return default return type
         if (! $argumentType instanceof ConstantStringType) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $args,
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return null;
         }
 
         // Called with a constant string $output

--- a/src/GetPermalinkDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPermalinkDynamicFunctionReturnTypeExtension.php
@@ -33,6 +33,7 @@ class GetPermalinkDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
      * @see https://developer.wordpress.org/reference/functions/get_permalink/
      * @see https://developer.wordpress.org/reference/functions/get_the_permalink/
      */
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         $args = $functionCall->getArgs();

--- a/src/MySQL2DateDynamicFunctionReturnTypeExtension.php
+++ b/src/MySQL2DateDynamicFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\StringType;
@@ -29,18 +28,15 @@ class MySQL2DateDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
     /**
      * @see https://developer.wordpress.org/reference/functions/mysql2date/
      */
-    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         $args = $functionCall->getArgs();
         $argumentType = $scope->getType($args[0]->value);
 
         // When called with a $format that isn't a constant string, return default return type
         if (! $argumentType instanceof ConstantStringType) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $args,
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return null;
         }
 
         // Called with a constant string $format

--- a/src/ShortcodeAttsDynamicFunctionReturnTypeExtension.php
+++ b/src/ShortcodeAttsDynamicFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -24,15 +23,12 @@ final class ShortcodeAttsDynamicFunctionReturnTypeExtension implements \PHPStan\
         return $functionReflection->getName() === 'shortcode_atts';
     }
 
-    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         $args = $functionCall->getArgs();
         if ($args === []) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $args,
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return null;
         }
 
         $type = $scope->getType($args[0]->value);

--- a/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
+++ b/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
@@ -11,7 +11,6 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\StringType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
@@ -24,16 +23,13 @@ class StringOrArrayDynamicFunctionReturnTypeExtension implements \PHPStan\Type\D
         return in_array($functionReflection->getName(), ['esc_sql', 'wp_slash', 'wp_unslash'], true);
     }
 
-    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         $args = $functionCall->getArgs();
         $argsCount = count($args);
         if ($argsCount === 0) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $args,
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return null;
         }
         $dataArg = $args[0]->value;
         $dataArgType = $scope->getType($dataArg);

--- a/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
@@ -15,7 +15,6 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\Constant\ConstantIntegerType;
@@ -55,12 +54,11 @@ final class WpParseUrlFunctionDynamicReturnTypeExtension implements \PHPStan\Typ
         return $functionReflection->getName() === 'wp_parse_url';
     }
 
-    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): Type
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
         if (count($functionCall->getArgs()) < 1) {
-            return ParametersAcceptorSelector::selectSingle(
-                $functionReflection->getVariants()
-            )->getReturnType();
+            return null;
         }
 
         $this->cacheReturnTypes();


### PR DESCRIPTION
Simplifies returning the default return type by replacing `return ParametersAcceptorSelector::selectFromArgs(...)->getReturnType();` with `return null;`.