### PR TITLE
Add dynamic function return type for `get_post_permalink()`

### DIFF
--- a/src/GetPermalinkDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPermalinkDynamicFunctionReturnTypeExtension.php
@@ -24,6 +24,7 @@ class GetPermalinkDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
             [
                 'get_permalink',
                 'get_the_permalink',
+                'get_post_permalink',
             ],
             true
         );

--- a/tests/data/get_permalink.php
+++ b/tests/data/get_permalink.php
@@ -7,6 +7,7 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 use stdClass;
 
 use function get_permalink;
+use function get_post_permalink;
 use function get_the_permalink;
 use function PHPStan\Testing\assertType;
 
@@ -22,3 +23,8 @@ assertType('string', get_permalink($wpPostType));
 assertType('string|false', get_the_permalink());
 assertType('string|false', get_the_permalink($_GET['foo']));
 assertType('string', get_the_permalink($wpPostType));
+
+// get_post_permalink()
+assertType('string|false', get_post_permalink());
+assertType('string|false', get_post_permalink($_GET['foo']));
+assertType('string', get_post_permalink($wpPostType));


### PR DESCRIPTION
Adds `get_post_permalink()` to `GetPermalinkDynamicFunctionReturnTypeExtension`