### PR TITLE
Add return types for query strings to echo key extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
-        "phpstan/phpstan": "^1.8.7",
+        "phpstan/phpstan": "^1.9.4",
         "symfony/polyfill-php73": "^1.12.0"
     },
     "require-dev": {

--- a/src/EchoKeyDynamicFunctionReturnTypeExtension.php
+++ b/src/EchoKeyDynamicFunctionReturnTypeExtension.php
@@ -53,7 +53,7 @@ class EchoKeyDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynamic
     ];
 
     /**
-     * Function that can return void even if `$echo` is falsey.
+     * Functions that can return void even if `$echo` is falsey.
      */
     private const ALWAYS_VOID = [
         'the_title_attribute',

--- a/tests/data/echo_key.php
+++ b/tests/data/echo_key.php
@@ -103,8 +103,8 @@ assertType('string|void', wp_list_users($args));
 assertType('string|void', wp_login_form($args));
 assertType('string|void', wp_page_menu($args));
 
-// Explicit query string value of true
-$args = 'echo=true&akey=avalue';
+// Explicit no query string value
+$args = 'akey=avalue';
 assertType('void', the_title_attribute($args));
 assertType('void', wp_dropdown_categories($args));
 assertType('void', wp_dropdown_languages($args));
@@ -120,19 +120,42 @@ assertType('void', wp_list_pages($args));
 assertType('void', wp_list_users($args));
 assertType('void', wp_page_menu($args));
 
-// Explicit query string value of 1
-$args = 'echo=1&akey=avalue';
+// Explicit non empty non numeric query string value (includes 'true' & 'false')
+$args = 'echo=nonemptynonnumeric&akey=avalue';
+assertType('void', the_title_attribute($args));
 assertType('void', wp_dropdown_categories($args));
 assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_dropdown_pages($args));
 assertType('void', wp_dropdown_users($args));
 assertType('void', wp_get_archives($args));
 assertType('void', wp_link_pages($args));
+assertType('void', wp_list_authors($args));
 assertType('void', wp_list_bookmarks($args));
 assertType('void|false', wp_list_categories($args));
+assertType('void', wp_list_comments($args));
+assertType('void', wp_list_pages($args));
+assertType('void', wp_list_users($args));
+assertType('void', wp_page_menu($args));
 
-// Explicit query string value of false
-$args = 'echo=false&akey=avalue';
+// Explicit non zero numeric query string value
+$args = 'echo=1&akey=avalue';
+assertType('void', the_title_attribute($args));
+assertType('void', wp_dropdown_categories($args));
+assertType('void', wp_dropdown_languages($args));
+assertType('void', wp_dropdown_pages($args));
+assertType('void', wp_dropdown_users($args));
+assertType('void', wp_get_archives($args));
+assertType('void', wp_link_pages($args));
+assertType('void', wp_list_authors($args));
+assertType('void', wp_list_bookmarks($args));
+assertType('void|false', wp_list_categories($args));
+assertType('void', wp_list_comments($args));
+assertType('void', wp_list_pages($args));
+assertType('void', wp_list_users($args));
+assertType('void', wp_page_menu($args));
+
+// Explicit query string value of 0
+$args = 'echo=0&akey=avalue';
 assertType('string|void', the_title_attribute($args));
 assertType('string', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
@@ -148,16 +171,22 @@ assertType('string', wp_list_pages($args));
 assertType('string', wp_list_users($args));
 assertType('string', wp_page_menu($args));
 
-// Explicit query string value of 0
-$args = 'echo=0&akey=avalue';
+// Explicit empty query string value
+$args = 'echo=&akey=avalue';
+assertType('string|void', the_title_attribute($args));
 assertType('string', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
 assertType('string', wp_dropdown_pages($args));
 assertType('string', wp_dropdown_users($args));
 assertType('string|void', wp_get_archives($args));
 assertType('string', wp_link_pages($args));
+assertType('string', wp_list_authors($args));
 assertType('string', wp_list_bookmarks($args));
 assertType('string|false', wp_list_categories($args));
+assertType('string|void', wp_list_comments($args));
+assertType('string', wp_list_pages($args));
+assertType('string', wp_list_users($args));
+assertType('string', wp_page_menu($args));
 
 // Unknown value
 $args = $_GET['foo'];

--- a/tests/data/echo_key.php
+++ b/tests/data/echo_key.php
@@ -24,7 +24,7 @@ assertType('void', wp_list_users());
 assertType('void', wp_login_form());
 assertType('void', wp_page_menu());
 
-// Explicit value of true
+// Explicit array key value of true
 $args = ['echo' => true];
 assertType('void', get_search_form($args));
 assertType('void', the_title_attribute($args));
@@ -43,7 +43,7 @@ assertType('void', wp_list_users($args));
 assertType('void', wp_login_form($args));
 assertType('void', wp_page_menu($args));
 
-// Explicit value of 1
+// Explicit array key value of 1
 $args = ['echo' => 1];
 assertType('void', wp_dropdown_categories($args));
 assertType('void', wp_dropdown_languages($args));
@@ -54,7 +54,7 @@ assertType('void', wp_link_pages($args));
 assertType('void', wp_list_bookmarks($args));
 assertType('void|false', wp_list_categories($args));
 
-// Explicit value of false
+// Explicit array key value of false
 $args = ['echo' => false];
 assertType('string', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
@@ -72,3 +72,108 @@ assertType('string', wp_list_pages($args));
 assertType('string', wp_list_users($args));
 assertType('string', wp_login_form($args));
 assertType('string', wp_page_menu($args));
+
+// Explicit array key value of 0
+$args = ['echo' => 0];
+assertType('string', wp_dropdown_categories($args));
+assertType('string|void', wp_dropdown_languages($args));
+assertType('string', wp_dropdown_pages($args));
+assertType('string', wp_dropdown_users($args));
+assertType('string|void', wp_get_archives($args));
+assertType('string', wp_link_pages($args));
+assertType('string', wp_list_bookmarks($args));
+assertType('string|false', wp_list_categories($args));
+
+// Unknown array key value
+$args = ['echo' => $_GET['foo']];
+assertType('string|void', get_search_form($args));
+assertType('string|void', the_title_attribute($args));
+assertType('string|void', wp_dropdown_categories($args));
+assertType('string|void', wp_dropdown_languages($args));
+assertType('string|void', wp_dropdown_pages($args));
+assertType('string|void', wp_dropdown_users($args));
+assertType('string|void', wp_get_archives($args));
+assertType('string|void', wp_link_pages($args));
+assertType('string|void', wp_list_authors($args));
+assertType('string|void', wp_list_bookmarks($args));
+assertType('string|void|false', wp_list_categories($args));
+assertType('string|void', wp_list_comments($args));
+assertType('string|void', wp_list_pages($args));
+assertType('string|void', wp_list_users($args));
+assertType('string|void', wp_login_form($args));
+assertType('string|void', wp_page_menu($args));
+
+// Explicit query string value of true
+$args = 'echo=true&akey=avalue';
+assertType('void', the_title_attribute($args));
+assertType('void', wp_dropdown_categories($args));
+assertType('void', wp_dropdown_languages($args));
+assertType('void', wp_dropdown_pages($args));
+assertType('void', wp_dropdown_users($args));
+assertType('void', wp_get_archives($args));
+assertType('void', wp_link_pages($args));
+assertType('void', wp_list_authors($args));
+assertType('void', wp_list_bookmarks($args));
+assertType('void|false', wp_list_categories($args));
+assertType('void', wp_list_comments($args));
+assertType('void', wp_list_pages($args));
+assertType('void', wp_list_users($args));
+assertType('void', wp_page_menu($args));
+
+// Explicit query string value of 1
+$args = 'echo=1&akey=avalue';
+assertType('void', wp_dropdown_categories($args));
+assertType('void', wp_dropdown_languages($args));
+assertType('void', wp_dropdown_pages($args));
+assertType('void', wp_dropdown_users($args));
+assertType('void', wp_get_archives($args));
+assertType('void', wp_link_pages($args));
+assertType('void', wp_list_bookmarks($args));
+assertType('void|false', wp_list_categories($args));
+
+// Explicit query string value of false
+$args = 'echo=false&akey=avalue';
+assertType('string|void', the_title_attribute($args));
+assertType('string', wp_dropdown_categories($args));
+assertType('string|void', wp_dropdown_languages($args));
+assertType('string', wp_dropdown_pages($args));
+assertType('string', wp_dropdown_users($args));
+assertType('string|void', wp_get_archives($args));
+assertType('string', wp_link_pages($args));
+assertType('string', wp_list_authors($args));
+assertType('string', wp_list_bookmarks($args));
+assertType('string|false', wp_list_categories($args));
+assertType('string|void', wp_list_comments($args));
+assertType('string', wp_list_pages($args));
+assertType('string', wp_list_users($args));
+assertType('string', wp_page_menu($args));
+
+// Explicit query string value of 0
+$args = 'echo=0&akey=avalue';
+assertType('string', wp_dropdown_categories($args));
+assertType('string|void', wp_dropdown_languages($args));
+assertType('string', wp_dropdown_pages($args));
+assertType('string', wp_dropdown_users($args));
+assertType('string|void', wp_get_archives($args));
+assertType('string', wp_link_pages($args));
+assertType('string', wp_list_bookmarks($args));
+assertType('string|false', wp_list_categories($args));
+
+// Unknown value
+$args = $_GET['foo'];
+assertType('string|void', get_search_form($args));
+assertType('string|void', the_title_attribute($args));
+assertType('string|void', wp_dropdown_categories($args));
+assertType('string|void', wp_dropdown_languages($args));
+assertType('string|void', wp_dropdown_pages($args));
+assertType('string|void', wp_dropdown_users($args));
+assertType('string|void', wp_get_archives($args));
+assertType('string|void', wp_link_pages($args));
+assertType('string|void', wp_list_authors($args));
+assertType('string|void', wp_list_bookmarks($args));
+assertType('string|void|false', wp_list_categories($args));
+assertType('string|void', wp_list_comments($args));
+assertType('string|void', wp_list_pages($args));
+assertType('string|void', wp_list_users($args));
+assertType('string|void', wp_login_form($args));
+assertType('string|void', wp_page_menu($args));


### PR DESCRIPTION
This PR addresses `EchoKeyDynamicFunctionReturnTypeExtension`. It
* adds return types for query string arguments,
* adds tests for `$args['echo']=0`, unknown values and function calls with query string,
* improves the logic of the helper methods.
