### PR TITLE
Add dynamic return type extension for `wp_tag_cloud()`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -16,6 +16,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: SzepeViktor\PHPStan\WordPress\WpTagCloudDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\GetPermalinkDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/WpTagCloudDynamicFunctionReturnTypeExtension.php
+++ b/src/WpTagCloudDynamicFunctionReturnTypeExtension.php
@@ -57,7 +57,7 @@ class WpTagCloudDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
                 : $this->getReturnType('indetermined');
         }
 
-        // Now constanst arrays are left.
+        // Now constants arrays are left.
 
         $this->setIsEchoTrue();
 

--- a/src/WpTagCloudDynamicFunctionReturnTypeExtension.php
+++ b/src/WpTagCloudDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Set return type of various functions that support an `$echo` or `$display` parameter.
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VoidType;
+
+class WpTagCloudDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    /** @var \PHPStan\Type\Type */
+    private $argType;
+
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'wp_tag_cloud';
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/functions/wp_tag_cloud/
+     *
+     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+     */
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+    {
+        $args = $functionCall->getArgs();
+
+        if (count($args) === 0) {
+            return new VoidType();
+        }
+
+        $this->argType = $scope->getType($args[0]->value);
+
+        $echoType = $this->getEchoType();
+        $formatType = $this->getFormatType();
+
+        if (
+            $echoType instanceof ConstantBooleanType &&
+            $echoType->getValue() === true
+        ) {
+            return new VoidType();
+        }
+
+        if ($formatType instanceof ConstantStringType) {
+            $returnType = $formatType->getValue() === 'array'
+                ? new ArrayType(new IntegerType(), new StringType())
+                : new StringType();
+            return TypeCombinator::union($returnType, new VoidType());
+        }
+
+        return TypeCombinator::union(
+            new ArrayType(new IntegerType(), new StringType()),
+            new StringType(),
+            new VoidType()
+        );
+    }
+
+    private function getEchoType(): Type
+    {
+        if ($this->argType instanceof ConstantArrayType) {
+            $type = self::getTypeFromKey($this->argType, 'echo');
+            return $type ?? new ConstantBooleanType(true);
+        }
+        if ($this->argType instanceof ConstantStringType) {
+            $type = self::getTypeFromString($this->argType, 'echo');
+            return $type ?? new ConstantBooleanType(true);
+        }
+        return new MixedType();
+    }
+
+    private function getFormatType(): Type
+    {
+        if ($this->argType instanceof ConstantArrayType) {
+            $type = self::getTypeFromKey($this->argType, 'format');
+            return $type ?? new ConstantStringType('flat');
+        }
+        if ($this->argType instanceof ConstantStringType) {
+            $type = self::getTypeFromString($this->argType, 'format');
+            return $type ?? new ConstantStringType('flat');
+        }
+        return new MixedType();
+    }
+
+    private static function getTypeFromKey(ConstantArrayType $type, string $key): ?Type
+    {
+        foreach ($type->getKeyTypes() as $index => $keyType) {
+            if (
+                !($keyType instanceof ConstantStringType) ||
+                $keyType->getValue() !== $key
+            ) {
+                continue;
+            }
+            return $type->getValueTypes()[$index];
+        }
+        return null;
+    }
+
+    private static function getTypeFromString(ConstantStringType $type, string $key): ?Type
+    {
+        if (strpos($type->getValue(), "{$key}=") === false) {
+            return null;
+        }
+
+        parse_str($type->getValue(), $parsed);
+        return isset($parsed[$key])
+            ? new ConstantStringType($parsed[$key])
+            : null;
+    }
+}

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -32,6 +32,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_parse_url.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_die.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_tag_cloud.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_theme_get.php');
     }
 

--- a/tests/data/wp_tag_cloud.php
+++ b/tests/data/wp_tag_cloud.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
+use function wp_tag_cloud;
 use function PHPStan\Testing\assertType;
 
 // Default
@@ -18,14 +19,14 @@ assertType('string|void', wp_tag_cloud(['echo' => false]));
 assertType('string|void', wp_tag_cloud(['echo' => $_GET['foo']]));
 
 // Vary $args['format'] with default $args['echo']
-assertType('void', wp_tag_cloud(['format' => 'array']));
+assertType('array<int, string>|void', wp_tag_cloud(['format' => 'array']));
 assertType('void', wp_tag_cloud(['format' => 'flat']));
-assertType('void', wp_tag_cloud(['format' => $_GET['foo']]));
+assertType('array<int, string>|void', wp_tag_cloud(['format' => $_GET['foo']]));
 
 // Vary $args['format'] with $args['echo'] = true
-assertType('void', wp_tag_cloud(['echo' => true, 'format' => 'array']));
+assertType('array<int, string>|void', wp_tag_cloud(['echo' => true, 'format' => 'array']));
 assertType('void', wp_tag_cloud(['echo' => true, 'format' => 'flat']));
-assertType('void', wp_tag_cloud(['echo' => true, 'format' => $_GET['foo']]));
+assertType('array<int, string>|void', wp_tag_cloud(['echo' => true, 'format' => $_GET['foo']]));
 
 // Vary $args['format'] with $args['echo'] = false
 assertType('array<int, string>|void', wp_tag_cloud(['echo' => false, 'format' => 'array']));

--- a/tests/data/wp_tag_cloud.php
+++ b/tests/data/wp_tag_cloud.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function PHPStan\Testing\assertType;
+
+// Default
+assertType('void', wp_tag_cloud());
+
+// Unknwon
+assertType('array<int, string>|string|void', wp_tag_cloud($_GET['foo']));
+
+// Vary $args['echo'] with default $args['format']
+assertType('void', wp_tag_cloud(['echo' => true]));
+assertType('string|void', wp_tag_cloud(['echo' => false]));
+assertType('string|void', wp_tag_cloud(['echo' => $_GET['foo']]));
+
+// Vary $args['format'] with default $args['echo']
+assertType('void', wp_tag_cloud(['format' => 'array']));
+assertType('void', wp_tag_cloud(['format' => 'flat']));
+assertType('void', wp_tag_cloud(['format' => $_GET['foo']]));
+
+// Vary $args['format'] with $args['echo'] = true
+assertType('void', wp_tag_cloud(['echo' => true, 'format' => 'array']));
+assertType('void', wp_tag_cloud(['echo' => true, 'format' => 'flat']));
+assertType('void', wp_tag_cloud(['echo' => true, 'format' => $_GET['foo']]));
+
+// Vary $args['format'] with $args['echo'] = false
+assertType('array<int, string>|void', wp_tag_cloud(['echo' => false, 'format' => 'array']));
+assertType('string|void', wp_tag_cloud(['echo' => false, 'format' => 'flat']));
+assertType('array<int, string>|string|void', wp_tag_cloud(['echo' => false, 'format' => $_GET['foo']]));
+
+// Vary $args['format'] with unknwon $args['echo']
+assertType('array<int, string>|void', wp_tag_cloud(['echo' => $_GET['foo'], 'format' => 'array']));
+assertType('string|void', wp_tag_cloud(['echo' => $_GET['foo'], 'format' => 'flat']));
+assertType('array<int, string>|string|void', wp_tag_cloud(['echo' => $_GET['foo'], 'format' => $_GET['baz']]));

--- a/tests/data/wp_tag_cloud.php
+++ b/tests/data/wp_tag_cloud.php
@@ -10,7 +10,7 @@ use function PHPStan\Testing\assertType;
 // Default
 assertType('void', wp_tag_cloud());
 
-// Unknwon
+// Unknown
 assertType('array<int, string>|string|void', wp_tag_cloud($_GET['foo']));
 
 // Vary $args['echo'] with default $args['format']
@@ -33,7 +33,7 @@ assertType('array<int, string>|void', wp_tag_cloud(['echo' => false, 'format' =>
 assertType('string|void', wp_tag_cloud(['echo' => false, 'format' => 'flat']));
 assertType('array<int, string>|string|void', wp_tag_cloud(['echo' => false, 'format' => $_GET['foo']]));
 
-// Vary $args['format'] with unknwon $args['echo']
+// Vary $args['format'] with unknown $args['echo']
 assertType('array<int, string>|void', wp_tag_cloud(['echo' => $_GET['foo'], 'format' => 'array']));
 assertType('string|void', wp_tag_cloud(['echo' => $_GET['foo'], 'format' => 'flat']));
 assertType('array<int, string>|string|void', wp_tag_cloud(['echo' => $_GET['foo'], 'format' => $_GET['baz']]));


### PR DESCRIPTION
This PR adds a dynamic function return type extension for `wp_tag_cloud()`.

I have made several updates to the extension since the initial draft:
* It now only checks for an array parameter or an empty string.
* The use of `instanceof` has been removed.
* It requires version 5.8.4+ of [wordpress-stubs](https://github.com/php-stubs/wordpress-stubs).