### PR TITLE
Improve `get_comment()` return type extension

### DIFF
--- a/src/GetCommentDynamicFunctionReturnTypeExtension.php
+++ b/src/GetCommentDynamicFunctionReturnTypeExtension.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress;
 
-use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Type;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\StringType;
@@ -20,38 +20,63 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\TypeCombinator;
-use PHPStan\Type\Constant\ConstantStringType;
+use WP_Comment;
 
 class GetCommentDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
-        return in_array($functionReflection->getName(), ['get_comment'], true);
+        return $functionReflection->getName() === 'get_comment';
     }
 
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
-        $output = 'OBJECT';
         $args = $functionCall->getArgs();
+        $returnType = [new NullType()];
+
+        if (
+            count($args) > 0 &&
+            (new ObjectType(WP_Comment::class))->isSuperTypeOf($scope->getType($args[0]->value))->yes()
+        ) {
+            $returnType = [];
+        }
+
+        if (count($args) < 2) {
+            $returnType[] = new ObjectType(WP_Comment::class);
+        }
 
         if (count($args) >= 2) {
+            $outputType = $scope->getType($args[1]->value);
+
             // When called with an $output that isn't a constant string, return default return type
-            if (! $scope->getType($args[1]->value) instanceof ConstantStringType) {
+            if (count($outputType->getConstantStrings()) === 0) {
+                if ($returnType === []) {
+                    return TypeCombinator::removeNull(
+                        ParametersAcceptorSelector::selectFromArgs(
+                            $scope,
+                            $args,
+                            $functionReflection->getVariants()
+                        )->getReturnType()
+                    );
+                }
                 return null;
+            }
+
+            foreach ($outputType->getConstantStrings() as $constantString) {
+                switch ($constantString->getValue()) {
+                    case 'ARRAY_A':
+                        $returnType[] = new ArrayType(new StringType(), new MixedType());
+                        break;
+                    case 'ARRAY_N':
+                        $returnType[] = new ArrayType(new IntegerType(), new MixedType());
+                        break;
+                    default:
+                        $returnType[] = new ObjectType(WP_Comment::class);
+                }
             }
         }
 
-        if (count($args) >= 2 && $args[1]->value instanceof ConstFetch) {
-            $output = $args[1]->value->name->getLast();
-        }
-        if ($output === 'ARRAY_A') {
-            return TypeCombinator::union(new ArrayType(new StringType(), new MixedType()), new NullType());
-        }
-        if ($output === 'ARRAY_N') {
-            return TypeCombinator::union(new ArrayType(new IntegerType(), new MixedType()), new NullType());
-        }
-
-        return TypeCombinator::union(new ObjectType('WP_Comment'), new NullType());
+        return TypeCombinator::union(...$returnType);
     }
 }

--- a/tests/data/get_comment.php
+++ b/tests/data/get_comment.php
@@ -6,16 +6,23 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 
 use function PHPStan\Testing\assertType;
 
+/** @var \WP_Comment $comment */
+$comment = $comment;
+
 // Default output
+assertType('WP_Comment|null', get_comment());
 assertType('WP_Comment|null', get_comment(1));
 assertType('WP_Comment|null', get_comment(1, OBJECT));
 assertType('WP_Comment|null', get_comment(1, 'Hello'));
 
 // Unknown output
 assertType('array|WP_Comment|null', get_comment(1, $_GET['foo']));
+assertType('array|WP_Comment', get_comment($comment, $_GET['foo']));
 
 // Associative array output
 assertType('array<string, mixed>|null', get_comment(1, ARRAY_A));
+assertType('array<string, mixed>', get_comment($comment, ARRAY_A));
 
 // Numeric array output
 assertType('array<int, mixed>|null', get_comment(1, ARRAY_N));
+assertType('array<int, mixed>', get_comment($comment, ARRAY_N));


### PR DESCRIPTION
This PR
* improves the dynamic return type extension for `get_comment()` by also checking the first argument and removing the null type if applicable,
* replaces the deprecated `$type instanceof ConstantStringType`,
* adds tests for the first argument being an instance of `WP_Comment` and for the no argument case.