### PR TITLE
Fix dynamic return type extension for `has_filter()`/`has_action()`

### DIFF
--- a/src/HasFilterDynamicFunctionReturnTypeExtension.php
+++ b/src/HasFilterDynamicFunctionReturnTypeExtension.php
@@ -15,7 +15,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\IntegerType;
-use PHPStan\Type\MixedType;
 use PHPStan\Type\TypeCombinator;
 
 class HasFilterDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
@@ -35,20 +34,15 @@ class HasFilterDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynam
             $callbackArgumentType = $scope->getType($args[1]->value);
         }
 
-        if (($callbackArgumentType instanceof ConstantBooleanType) && ($callbackArgumentType->getValue() === false)) {
+        if ($callbackArgumentType->isFalse()->yes()) {
             return new BooleanType();
         }
 
-        if ($callbackArgumentType instanceof MixedType) {
-            return TypeCombinator::union(
-                new BooleanType(),
-                new IntegerType()
-            );
+        $returnType = [new ConstantBooleanType(false), new IntegerType()];
+        if ($callbackArgumentType->isFalse()->maybe()) {
+            $returnType[] = new BooleanType();
         }
 
-        return TypeCombinator::union(
-            new ConstantBooleanType(false),
-            new IntegerType()
-        );
+        return TypeCombinator::union(...$returnType);
     }
 }

--- a/tests/data/has_filter.php
+++ b/tests/data/has_filter.php
@@ -18,6 +18,12 @@ assertType('bool', has_action('', false));
 assertType('int|false', has_filter('', 'intval'));
 assertType('int|false', has_action('', 'intval'));
 
+// Maybe false callback
+/** @var callable|string|array|false $callback */
+$callback = $_GET['callback'];
+assertType('bool|int', has_filter('', $callback));
+assertType('bool|int', has_action('', $callback));
+
 // Unknown callback
 $callback = $_GET['callback'] ?? 'foo';
 assertType('bool|int', has_filter('', $callback));


### PR DESCRIPTION
This PR fixes the return type of `has_filter()` and `has_action()` for maybe false types.

A maybe false type such as `callable|string|array|false` is not an instance of MixedType in 
https://github.com/szepeviktor/phpstan-wordpress/blob/5c6c6c47b77251ba2c0753c3ff8842cb08190f9e/src/HasFilterDynamicFunctionReturnTypeExtension.php#L42-L47

Failing test:
```php
// Maybe false callback
/** @var callable|string|array|false $callback */
$callback = $_GET['callback'];
assertType('bool|int', has_filter('', $callback));
assertType('bool|int', has_action('', $callback));
```

This PR also replaces a deprecated `instanceof ConstantBooleanType`.

