### PR TITLE
Fix dynamic return type extension for `term_exists()`

### DIFF
--- a/src/TermExistsDynamicFunctionReturnTypeExtension.php
+++ b/src/TermExistsDynamicFunctionReturnTypeExtension.php
@@ -84,12 +84,9 @@ class TermExistsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
         }
 
         foreach ($taxonomyType->getConstantStrings() as $constantString) {
-            if ($constantString->getValue() !== '') {
-                $returnType[] = $withTaxonomy;
-            }
-            if ($constantString->getValue() === '') {
-                $returnType[] = $withoutTaxonomy;
-            }
+            $returnType[] = $constantString->getValue() === ''
+                ? $withoutTaxonomy
+                : $withTaxonomy;
         }
         return TypeCombinator::union(...$returnType);
     }

--- a/src/TermExistsDynamicFunctionReturnTypeExtension.php
+++ b/src/TermExistsDynamicFunctionReturnTypeExtension.php
@@ -51,12 +51,18 @@ class TermExistsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
         $termType = $scope->getType($args[0]->value);
         $taxonomyType = isset($args[1]) ? $scope->getType($args[1]->value) : new ConstantStringType('');
 
-        if ($termType instanceof NullType) {
+        $returnType = [new NullType()];
+
+        if ($termType->isNull()->yes()) {
             return new NullType();
         }
 
-        if (($termType instanceof ConstantIntegerType) && $termType->getValue() === 0) {
-            return new ConstantIntegerType(0);
+        if (($termType instanceof ConstantIntegerType)) {
+            if ($termType->getValue() === 0) {
+                return new ConstantIntegerType(0);
+            }
+        } elseif ($termType->isInteger()->no() === false) {
+            $returnType[] = new ConstantIntegerType(0);
         }
 
         $withTaxonomy = new ConstantArrayType(
@@ -71,24 +77,20 @@ class TermExistsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
         );
         $withoutTaxonomy = new StringType();
 
-        if (($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() !== '') {
-            return TypeCombinator::union(
-                $withTaxonomy,
-                new NullType()
-            );
+        if (count($taxonomyType->getConstantStrings()) !== 0) {
+            foreach ($taxonomyType->getConstantStrings() as $constantString) {
+                if ($constantString->getValue() !== '') {
+                    $returnType[] = $withTaxonomy;
+                }
+                if ($constantString->getValue() === '') {
+                    $returnType[] = $withoutTaxonomy;
+                }
+            }
+            return TypeCombinator::union(...$returnType);
         }
 
-        if (($taxonomyType instanceof ConstantStringType) && $taxonomyType->getValue() === '') {
-            return TypeCombinator::union(
-                $withoutTaxonomy,
-                new NullType()
-            );
-        }
-
-        return TypeCombinator::union(
-            $withTaxonomy,
-            $withoutTaxonomy,
-            new NullType()
-        );
+        $returnType[] = $withTaxonomy;
+        $returnType[] = $withoutTaxonomy;
+        return TypeCombinator::union(...$returnType);
     }
 }

--- a/src/TermExistsDynamicFunctionReturnTypeExtension.php
+++ b/src/TermExistsDynamicFunctionReturnTypeExtension.php
@@ -77,20 +77,20 @@ class TermExistsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dyna
         );
         $withoutTaxonomy = new StringType();
 
-        if (count($taxonomyType->getConstantStrings()) !== 0) {
-            foreach ($taxonomyType->getConstantStrings() as $constantString) {
-                if ($constantString->getValue() !== '') {
-                    $returnType[] = $withTaxonomy;
-                }
-                if ($constantString->getValue() === '') {
-                    $returnType[] = $withoutTaxonomy;
-                }
-            }
+        if (count($taxonomyType->getConstantStrings()) === 0) {
+            $returnType[] = $withTaxonomy;
+            $returnType[] = $withoutTaxonomy;
             return TypeCombinator::union(...$returnType);
         }
 
-        $returnType[] = $withTaxonomy;
-        $returnType[] = $withoutTaxonomy;
+        foreach ($taxonomyType->getConstantStrings() as $constantString) {
+            if ($constantString->getValue() !== '') {
+                $returnType[] = $withTaxonomy;
+            }
+            if ($constantString->getValue() === '') {
+                $returnType[] = $withoutTaxonomy;
+            }
+        }
         return TypeCombinator::union(...$returnType);
     }
 }

--- a/tests/data/term_exists.php
+++ b/tests/data/term_exists.php
@@ -12,15 +12,16 @@ $taxo = $_GET['taxo'] ?? 'category';
 // Empty taxonomy
 assertType('string|null', term_exists(123));
 assertType('string|null', term_exists(123, ''));
-assertType('string|null', term_exists($term));
-assertType('string|null', term_exists($term, ''));
+assertType('0|string|null', term_exists($term));
+assertType('0|string|null', term_exists($term, ''));
 
 // Fixed taxonomy string
 assertType('array{term_id: string, term_taxonomy_id: string}|null', term_exists(123, 'category'));
-assertType('array{term_id: string, term_taxonomy_id: string}|null', term_exists($term, 'category'));
+assertType('0|array{term_id: string, term_taxonomy_id: string}|null', term_exists($term, 'category'));
 
 // Unknown taxonomy type
 assertType('array{term_id: string, term_taxonomy_id: string}|string|null', term_exists(123, $taxo));
+assertType('0|array{term_id: string, term_taxonomy_id: string}|string|null', term_exists($term, $taxo));
 
 // Term 0
 assertType('0', term_exists(0));


### PR DESCRIPTION
This PR fixes the return type of term_exists() for an integer type first parameter with unknown value. An unknown value can be `0` for which `term_exists()` returns 0. This PR also replaces the deprecated `$type instanceof ConstantIntegerType`.