### PR TITLE
Fix dynamic function return type extension for `get_sites()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
-        "phpstan/phpstan": "^1.9.4",
+        "phpstan/phpstan": "^1.10.0",
         "symfony/polyfill-php73": "^1.12.0"
     },
     "require-dev": {

--- a/src/GetSitesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetSitesDynamicFunctionReturnTypeExtension.php
@@ -116,8 +116,8 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
         }
 
         if (
-            in_array('ids', $fields, true) && count($fields) > 1 ||
-            !in_array('ids', $fields, true) && count($fields) > 0
+            (in_array('ids', $fields, true) && count($fields) > 1) ||
+            (!in_array('ids', $fields, true) && count($fields) > 0)
         ) {
             $returnType[] = new ArrayType(new IntegerType(), new ObjectType(WP_Site::class));
         }

--- a/src/GetSitesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetSitesDynamicFunctionReturnTypeExtension.php
@@ -115,7 +115,10 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
             $returnType[] = new ArrayType(new IntegerType(), new IntegerType());
         }
 
-        if (!in_array('ids', $fields, true)) {
+        if (
+            in_array('ids', $fields, true) && count($fields) > 1 ||
+            !in_array('ids', $fields, true) && count($fields) > 0
+        ) {
             $returnType[] = new ArrayType(new IntegerType(), new ObjectType(WP_Site::class));
         }
 

--- a/src/GetSitesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetSitesDynamicFunctionReturnTypeExtension.php
@@ -15,8 +15,8 @@ use PHPStan\Type\Type;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\Constant\ConstantArrayType;
-use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\TypeCombinator;
+use WP_Site;
 
 class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
@@ -36,41 +36,89 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
 
         // Called without arguments
         if (count($args) === 0) {
-            return new ArrayType(new IntegerType(), new ObjectType('WP_Site'));
+            return new ArrayType(new IntegerType(), new ObjectType(WP_Site::class));
         }
-
-        $fields = '';
 
         $argumentType = $scope->getType($args[0]->value);
 
-        // Called with an array argument
-        if ($argumentType instanceof ConstantArrayType) {
-            foreach ($argumentType->getKeyTypes() as $index => $key) {
-                if (! $key instanceof ConstantStringType || $key->getValue() !== 'fields') {
-                    continue;
-                }
+        // Called with a non constant argument
+        if (
+            count($argumentType->getConstantArrays()) === 0 &&
+            count($argumentType->getConstantStrings()) === 0
+        ) {
+            return TypeCombinator::union(
+                new ArrayType(new IntegerType(), new ObjectType(WP_Site::class)),
+                new ArrayType(new IntegerType(), new IntegerType()),
+                new IntegerType()
+            );
+        }
 
-                $fieldsType = $argumentType->getValueTypes()[$index];
-                if ($fieldsType instanceof ConstantStringType) {
-                    $fields = $fieldsType->getValue();
+        $fields = [];
+        $count = [];
+        $returnType = [];
+
+        // Called with a constant array argument
+        if (count($argumentType->getConstantArrays()) !== 0) {
+            foreach ($argumentType->getConstantArrays() as $constantArray) {
+                foreach ($constantArray->getKeyTypes() as $index => $key) {
+                    if (count($key->getConstantStrings()) === 0) {
+                        continue;
+                    }
+                    foreach ($key->getConstantStrings() as $constantKey) {
+                        if (!in_array($constantKey->getValue(), ['fields', 'count'], true)) {
+                            continue;
+                        }
+                        $fieldsType = $constantArray->getValueTypes()[$index];
+                        if (count($fieldsType->getConstantScalarValues()) === 0) {
+                            continue;
+                        }
+
+                        foreach ($fieldsType->getConstantScalarTypes() as $constantField) {
+                            if ($constantKey->getValue() === 'fields') {
+                                $fields[] = $constantField->getValue();
+                            }
+                            if ($constantKey->getValue() !== 'count') {
+                                continue;
+                            }
+
+                            $count[] = (bool)$constantField->getValue();
+                        }
+                    }
                 }
-                break;
+            }
+            if ($fields === []) {
+                $fields = [''];
+            }
+            if ($count === []) {
+                $count = [false];
             }
         }
 
-        // Called with a string argument
-        if ($argumentType instanceof ConstantStringType) {
-            parse_str($argumentType->getValue(), $variables);
-            $fields = $variables['fields'] ?? 'all';
+        // Called with a constant string argument
+        if (count($argumentType->getConstantStrings()) !== 0) {
+            foreach ($argumentType->getConstantStrings() as $constantString) {
+                parse_str($constantString->getValue(), $variables);
+                $fields[] = $variables['fields'] ?? '';
+                $count[] = isset($variables['count']) ? (bool)$variables['count'] : false;
+            }
         }
 
-        switch ($fields) {
-            case 'count':
-                return new IntegerType();
-            case 'ids':
-                return new ArrayType(new IntegerType(), new IntegerType());
-            default:
-                return new ArrayType(new IntegerType(), new ObjectType('WP_Site'));
+        if (in_array(true, $count, true) && count($count) === 1) {
+            return new IntegerType();
         }
+
+        if (in_array(true, $count, true)) {
+            $returnType[] = new IntegerType();
+        }
+
+        if (in_array('ids', $fields, true)) {
+            $returnType[] = new ArrayType(new IntegerType(), new IntegerType());
+        }
+
+        if (!in_array('ids', $fields, true)) {
+            $returnType[] = new ArrayType(new IntegerType(), new ObjectType(WP_Site::class));
+        }
+
+        return TypeCombinator::union(...$returnType);
     }
 }

--- a/tests/data/get_sites.php
+++ b/tests/data/get_sites.php
@@ -9,13 +9,18 @@ use function PHPStan\Testing\assertType;
 // Default parameter
 assertType('array<int, WP_Site>', get_sites());
 
-// Unknown array parameter
+// Non constant array parameter
 /** @var array<int|string,mixed> $value */
 $value = $_GET['foo'];
 assertType('array<int, int|WP_Site>|int', get_sites($value));
 
-// Unknown string parameter
+// Non constant string parameter
 /** @var string $value */
+$value = $_GET['foo'];
+assertType('array<int, int|WP_Site>|int', get_sites($value));
+
+// Unknown parameter
+/** @var mixed $value */
 $value = $_GET['foo'];
 assertType('array<int, int|WP_Site>|int', get_sites($value));
 

--- a/tests/data/get_sites.php
+++ b/tests/data/get_sites.php
@@ -6,6 +6,49 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 
 use function PHPStan\Testing\assertType;
 
+// Default parameter
 assertType('array<int, WP_Site>', get_sites());
-assertType('int', get_sites(['fields' => 'count']));
+
+// Unknown array parameter
+/** @var array<int|string,mixed> $value */
+$value = $_GET['foo'];
+assertType('array<int, int|WP_Site>|int', get_sites($value));
+
+// Unknown string parameter
+/** @var string $value */
+$value = $_GET['foo'];
+assertType('array<int, int|WP_Site>|int', get_sites($value));
+
+// Array parameter with explicit fields value.
 assertType('array<int, int>', get_sites(['fields' => 'ids']));
+assertType('array<int, WP_Site>', get_sites(['fields' => '']));
+assertType('array<int, WP_Site>', get_sites(['fields' => 'nonEmptyString']));
+
+// Array parameter with truthy count value.
+assertType('int', get_sites(['count' => true]));
+assertType('int', get_sites(['count' => 1]));
+assertType('int', get_sites(['count' => 'nonEmptyString']));
+assertType('int', get_sites(['fields' => '', 'count' => true]));
+assertType('int', get_sites(['fields' => '', 'count' => 1]));
+assertType('int', get_sites(['fields' => '', 'count' => 'nonEmptyString']));
+assertType('int', get_sites(['fields' => 'ids', 'count' => true]));
+assertType('int', get_sites(['fields' => 'ids', 'count' => 1]));
+assertType('int', get_sites(['fields' => 'ids', 'count' => 'nonEmptyString']));
+assertType('int', get_sites(['fields' => 'nonEmptyString', 'count' => true]));
+assertType('int', get_sites(['fields' => 'nonEmptyString', 'count' => 1]));
+assertType('int', get_sites(['fields' => 'nonEmptyString', 'count' => 'nonEmptyString']));
+
+// Array parameter with falsy count value.
+assertType('array<int, WP_Site>', get_sites(['count' => false]));
+assertType('array<int, WP_Site>', get_sites(['count' => 0]));
+assertType('array<int, WP_Site>', get_sites(['count' => '']));
+assertType('array<int, WP_Site>', get_sites(['fields' => '', 'count' => false]));
+assertType('array<int, WP_Site>', get_sites(['fields' => '', 'count' => 0]));
+assertType('array<int, WP_Site>', get_sites(['fields' => '', 'count' => '']));
+assertType('array<int, int>', get_sites(['fields' => 'ids', 'count' => false]));
+assertType('array<int, int>', get_sites(['fields' => 'ids', 'count' => 0]));
+assertType('array<int, int>', get_sites(['fields' => 'ids', 'count' => '']));
+assertType('array<int, WP_Site>', get_sites(['fields' => 'nonEmptyString', 'count' => false]));
+assertType('array<int, WP_Site>', get_sites(['fields' => 'nonEmptyString', 'count' => 0]));
+assertType('array<int, WP_Site>', get_sites(['fields' => 'nonEmptyString', 'count' => '']));
+


### PR DESCRIPTION
This PR
* fixes the dynamic function return type extension for `get_sites()`,
* adds correct tests,
* bumps the required minimum version of PHPStan to 1.10.0 (needed for `Type::getConstantScalarValues()`),
* removes deprecated `instanceof`.

What has been fixed?
* There is no `$args['fields'] = 'count'` but `$args['fields'] = 'ids'` and `$args['count']`. The extension now checks for both `$args['fields]` and `$args['count']`. Not properly checking for 'count' led to incorrect return types for truthy count types.
* A return type for indetermined argument type has been added.

Todo:
* Adding tests for string parameter.
