### PR TITLE
Refactor get_sites() extension to improve readability

### DIFF
--- a/src/GetSitesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetSitesDynamicFunctionReturnTypeExtension.php
@@ -74,7 +74,7 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
     /**
      * @param list<mixed> $fields
      * @param list<mixed> $count
-     * @return list<IntegerType|ArrayType>
+     * @return list<\PHPStan\Type\IntegerType|\PHPStan\Type\ArrayType>
      */
     private static function getReturnTypeFromArgs(array $fields, array $count): array
     {

--- a/src/GetSitesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetSitesDynamicFunctionReturnTypeExtension.php
@@ -16,6 +16,8 @@ use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
 use WP_Site;
 
 class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
@@ -26,7 +28,7 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
     }
 
     /**
-     * @see https://developer.wordpress.org/reference/classes/wp_query/#return-fields-parameter
+     * @see https://developer.wordpress.org/reference/functions/get_sites/
      *
      * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
      */
@@ -36,7 +38,7 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
 
         // Called without arguments
         if (count($args) === 0) {
-            return new ArrayType(new IntegerType(), new ObjectType(WP_Site::class));
+            return self::getDefaultType();
         }
 
         $argumentType = $scope->getType($args[0]->value);
@@ -46,66 +48,41 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
             count($argumentType->getConstantArrays()) === 0 &&
             count($argumentType->getConstantStrings()) === 0
         ) {
-            return TypeCombinator::union(
-                new ArrayType(new IntegerType(), new ObjectType(WP_Site::class)),
-                new ArrayType(new IntegerType(), new IntegerType()),
-                new IntegerType()
-            );
+            return self::getIndeterminedType();
         }
 
         $fields = [];
         $count = [];
-        $returnType = [];
 
         // Called with a constant array argument
         if (count($argumentType->getConstantArrays()) !== 0) {
             foreach ($argumentType->getConstantArrays() as $constantArray) {
-                foreach ($constantArray->getKeyTypes() as $index => $key) {
-                    if (count($key->getConstantStrings()) === 0) {
-                        continue;
-                    }
-                    foreach ($key->getConstantStrings() as $constantKey) {
-                        if (!in_array($constantKey->getValue(), ['fields', 'count'], true)) {
-                            continue;
-                        }
-                        $fieldsType = $constantArray->getValueTypes()[$index];
-                        if (count($fieldsType->getConstantScalarValues()) === 0) {
-                            continue;
-                        }
-
-                        foreach ($fieldsType->getConstantScalarTypes() as $constantField) {
-                            if ($constantKey->getValue() === 'fields') {
-                                $fields[] = $constantField->getValue();
-                            }
-                            if ($constantKey->getValue() !== 'count') {
-                                continue;
-                            }
-
-                            $count[] = (bool)$constantField->getValue();
-                        }
-                    }
-                }
-            }
-            if ($fields === []) {
-                $fields = [''];
-            }
-            if ($count === []) {
-                $count = [false];
+                self::getValuesFromArray($constantArray, $fields, $count);
             }
         }
 
         // Called with a constant string argument
         if (count($argumentType->getConstantStrings()) !== 0) {
             foreach ($argumentType->getConstantStrings() as $constantString) {
-                parse_str($constantString->getValue(), $variables);
-                $fields[] = $variables['fields'] ?? '';
-                $count[] = isset($variables['count']) ? (bool)$variables['count'] : false;
+                self::getValuesFromString($constantString, $fields, $count);
             }
         }
 
+        return TypeCombinator::union(...self::getReturnTypeFromArgs($fields, $count));
+    }
+
+    /**
+     * @param list<mixed> $fields
+     * @param list<mixed> $count
+     * @return list<IntegerType|ArrayType>
+     */
+    private static function getReturnTypeFromArgs(array $fields, array $count): array
+    {
         if (in_array(true, $count, true) && count($count) === 1) {
-            return new IntegerType();
+            return [new IntegerType()];
         }
+
+        $returnType = [];
 
         if (in_array(true, $count, true)) {
             $returnType[] = new IntegerType();
@@ -119,9 +96,77 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
             (in_array('ids', $fields, true) && count($fields) > 1) ||
             (!in_array('ids', $fields, true) && count($fields) > 0)
         ) {
-            $returnType[] = new ArrayType(new IntegerType(), new ObjectType(WP_Site::class));
+            $returnType[] = self::getDefaultType();
         }
 
-        return TypeCombinator::union(...$returnType);
+        return $returnType;
+    }
+
+    /**
+     * @param list<mixed> $fields
+     * @param list<mixed> $count
+     */
+    private static function getValuesFromArray(ConstantArrayType $constantArray, array &$fields, array &$count): void
+    {
+        foreach ($constantArray->getKeyTypes() as $index => $key) {
+            if (count($key->getConstantStrings()) === 0) {
+                continue;
+            }
+            foreach ($key->getConstantStrings() as $constantKey) {
+                if (!in_array($constantKey->getValue(), ['fields', 'count'], true)) {
+                    continue;
+                }
+                $fieldsType = $constantArray->getValueTypes()[$index];
+                if (count($fieldsType->getConstantScalarValues()) === 0) {
+                    continue;
+                }
+
+                foreach ($fieldsType->getConstantScalarTypes() as $constantField) {
+                    if ($constantKey->getValue() === 'fields') {
+                        $fields[] = $constantField->getValue();
+                    }
+                    if ($constantKey->getValue() !== 'count') {
+                        continue;
+                    }
+
+                    $count[] = (bool)$constantField->getValue();
+                }
+            }
+        }
+
+        // If fields and count are not set, add their default value.
+        if ($fields === []) {
+            $fields = [''];
+        }
+        if ($count !== []) {
+            return;
+        }
+
+        $count = [false];
+    }
+
+    /**
+     * @param list<mixed> $fields
+     * @param list<mixed> $count
+     */
+    private static function getValuesFromString(ConstantStringType $constantString, array &$fields, array &$count): void
+    {
+        parse_str($constantString->getValue(), $variables);
+        $fields[] = $variables['fields'] ?? '';
+        $count[] = isset($variables['count']) ? (bool)$variables['count'] : false;
+    }
+
+    private static function getIndeterminedType(): Type
+    {
+        return TypeCombinator::union(
+            new ArrayType(new IntegerType(), new ObjectType(WP_Site::class)),
+            new ArrayType(new IntegerType(), new IntegerType()),
+            new IntegerType()
+        );
+    }
+
+    private static function getDefaultType(): ArrayType
+    {
+        return new ArrayType(new IntegerType(), new ObjectType(WP_Site::class));
     }
 }


### PR DESCRIPTION
Refactors the dynamic function return type extension for `get_sites()` to improve readability.

Last PR addressing this extension :innocent: