### PR TITLE
GetSites extension: Remove duplicate values from array

### DIFF
--- a/src/GetSitesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetSitesDynamicFunctionReturnTypeExtension.php
@@ -22,10 +22,10 @@ use WP_Site;
 
 class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
-    /** @var list<mixed> $fields */
+    /** @var array<int,mixed> $fields */
     private $fields;
 
-    /** @var list<mixed> $count */
+    /** @var array<int,mixed> $count */
     private $count;
 
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
@@ -82,6 +82,9 @@ class GetSitesDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
      */
     private function getReturnTypeFromArgs(): array
     {
+        $this->fields = array_unique($this->fields);
+        $this->count = array_unique($this->count);
+
         if (in_array(true, $this->count, true) && count($this->count) === 1) {
             return [new IntegerType()];
         }


### PR DESCRIPTION
This PR removes duplicate values from the `$fields` and `$count` array as the `count($this->count)` and `count($this->fields)` logic relies on unique values. This ensures that statements like `count($this->count) === 1` are `true` even if there are two or more constant arrays with `$args['count'] = true`. 