### PR TITLE
Improve echo type handling in EchoKey extension

### DIFF
--- a/tests/data/echo_key.php
+++ b/tests/data/echo_key.php
@@ -206,3 +206,23 @@ assertType('string|void', wp_list_pages($args));
 assertType('string|void', wp_list_users($args));
 assertType('string|void', wp_login_form($args));
 assertType('string|void', wp_page_menu($args));
+
+// Explicit query string value of 0 or 1 is the same as unknown
+/** @var 'echo=0&akey=avalue'|'echo=1&akey=avalue' $args */
+$args = '';
+assertType('string|void', get_search_form($args));
+assertType('string|void', the_title_attribute($args));
+assertType('string|void', wp_dropdown_categories($args));
+assertType('string|void', wp_dropdown_languages($args));
+assertType('string|void', wp_dropdown_pages($args));
+assertType('string|void', wp_dropdown_users($args));
+assertType('string|void', wp_get_archives($args));
+assertType('string|void', wp_link_pages($args));
+assertType('string|void', wp_list_authors($args));
+assertType('string|void', wp_list_bookmarks($args));
+assertType('string|void|false', wp_list_categories($args));
+assertType('string|void', wp_list_comments($args));
+assertType('string|void', wp_list_pages($args));
+assertType('string|void', wp_list_users($args));
+assertType('string|void', wp_login_form($args));
+assertType('string|void', wp_page_menu($args));


### PR DESCRIPTION
Closes https://github.com/szepeviktor/phpstan-wordpress/issues/160

@IanDelMar check out the first one, we don't even have to care if it's a constant array or not :)

the second one feels a bit like an overkill, but it is more correct I guess..