### PR TITLE
Improve/fix type StringOrArray extension

### DIFF
--- a/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
+++ b/src/StringOrArrayDynamicFunctionReturnTypeExtension.php
@@ -11,10 +11,16 @@ namespace SzepeViktor\PHPStan\WordPress;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
-use PHPStan\Type\StringType;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\IntegerType;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IntersectionType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeTraverser;
+use PHPStan\Type\UnionType;
 
 class StringOrArrayDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
@@ -29,21 +35,63 @@ class StringOrArrayDynamicFunctionReturnTypeExtension implements \PHPStan\Type\D
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
     {
-        $args = $functionCall->getArgs();
-        if (count($args) === 0) {
+        if (count($functionCall->getArgs()) === 0) {
             return null;
         }
 
-        $dataArgType = $scope->getType($args[0]->value);
-        if ($dataArgType->isArray()->yes()) {
-            $keyType = $dataArgType->getIterableKeyType();
-            if ($keyType instanceof StringType) {
-                return new ArrayType(new StringType(), new StringType());
-            }
+        return TypeTraverser::map(
+            $scope->getType($functionCall->getArgs()[0]->value),
+            function (Type $type, callable $traverse): Type {
+                if ($type instanceof UnionType || $type instanceof IntersectionType) {
+                    // phpcs:ignore NeutronStandard.Functions.VariableFunctions.VariableFunction
+                    return $traverse($type);
+                }
 
-            return new ArrayType(new IntegerType(), new StringType());
+                return $this->getType($type);
+            }
+        );
+    }
+
+    private function getType(Type $type): Type
+    {
+        if ($type->isScalar()->yes()) {
+            return new StringType();
         }
 
-        return new StringType();
+        if (!$type->isArray()->yes()) {
+            return new ConstantStringType('');
+        }
+
+        if (count($type->getConstantArrays()) > 0) {
+            return TypeCombinator::union(
+                ...array_map(
+                    function (ConstantArrayType $constantArray): Type {
+                        $builder = ConstantArrayTypeBuilder::createEmpty();
+                        foreach ($constantArray->getKeyTypes() as $i => $keyType) {
+                            $builder->setOffsetValueType(
+                                $keyType,
+                                $this->getType($constantArray->getValueTypes()[$i]),
+                                $constantArray->isOptionalKey($i)
+                            );
+                        }
+
+                        return $builder->getArray();
+                    },
+                    $type->getConstantArrays()
+                )
+            );
+        }
+
+        return TypeCombinator::union(
+            ...array_map(
+                function (ArrayType $arrayType): Type {
+                    return $arrayType->setOffsetValueType(
+                        $arrayType->getIterableKeyType(),
+                        $this->getType($arrayType->getIterableValueType())
+                    );
+                },
+                $type->getArrays()
+            )
+        );
     }
 }

--- a/tests/data/esc_sql.php
+++ b/tests/data/esc_sql.php
@@ -9,13 +9,35 @@ use stdClass;
 use function PHPStan\Testing\assertType;
 
 // Indexed array as parameter
-assertType('array<int, string>', esc_sql(['someValue', 'toEscape']));
+assertType("array{string, string}", esc_sql(['someValue', 'toEscape']));
 
 // Associative array as parameter
-assertType('array<string, string>', esc_sql(['someValue' => 'toEscape']));
+assertType("array{someValue: string}", esc_sql(['someValue' => 'toEscape']));
 
 // String as parameter
 assertType('string', esc_sql('someValueToEscape'));
 
-// Wrong type provided (esc_sql() returns an empty string in that case)
-assertType('string', esc_sql(new stdClass()));
+// Wrong type provided
+assertType("''", esc_sql(new stdClass()));
+assertType("''", esc_sql(null));
+assertType("array{''}", esc_sql([null]));
+
+assertType('array{string}', esc_sql([true]));
+assertType('string', esc_sql(1));
+assertType('array{array{string}}', esc_sql([[1]]));
+assertType('array{array{key: string}}', esc_sql([['key' => 1]]));
+assertType('array{key: array{string}}', esc_sql(['key' => [1]]));
+assertType('array{key1: array{key2: string}}', esc_sql(['key1' => ['key2' => 1]]));
+
+/** @var array{foo?: 'something'}|array{bar: 'something else'} $union1 */
+$union1 = null;
+assertType("array{bar: string}|array{foo?: string}", esc_sql($union1));
+
+/** @var 'foo'|array{foo?: 'bar'} $union2 */
+$union2 = null;
+assertType("array{foo?: string}|string", esc_sql($union2));
+
+/** @var array{foo?: 'bar'}|null $union3 */
+$union3 = null;
+assertType("''|array{foo?: string}", esc_sql($union3));
+


### PR DESCRIPTION
Closes https://github.com/szepeviktor/phpstan-wordpress/issues/154

- Gets rid of deprecated `instanceof`
- Fixes return types for nested arrays
- Adds more type precision by not dropping array key types, supporting constant arrays and returning `''` in case of an invalid type input
- Adds support for union/intersection types