### PR TITLE
Add some more dynamic constants

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -120,6 +120,8 @@ parameters:
         - WP_DEBUG_LOG
         - EMPTY_TRASH_DAYS
         - WP_CLI
+        - COOKIE_DOMAIN
+        - SAVEQUERIES
     earlyTerminatingFunctionCalls:
         - wp_die
         - wp_send_json


### PR DESCRIPTION
This list is potentially endless, but here are two more constants that I've had to add to the `dynamicConstantNames` list in my own plugins.