### PR TITLE
Add SCRIPT_DEBUG as dynamic constant

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,6 +10,7 @@ define('WP_DEBUG', true);
 define('WP_DEBUG_LOG', true);
 define('WPMU_PLUGIN_DIR', './');
 define('EMPTY_TRASH_DAYS', 30 * 86400);
+define('SCRIPT_DEBUG', false);
 
 // Constants for expressing human-readable intervals.
 define('MINUTE_IN_SECONDS', 60);

--- a/extension.neon
+++ b/extension.neon
@@ -122,6 +122,7 @@ parameters:
         - WP_CLI
         - COOKIE_DOMAIN
         - SAVEQUERIES
+        - SCRIPT_DEBUG
     earlyTerminatingFunctionCalls:
         - wp_die
         - wp_send_json


### PR DESCRIPTION
See: https://github.com/WordPress/wordpress-develop/blob/e30ce9d4b57a38e7d7fe8c0665c71e444943c555/src/wp-includes/default-constants.php#L104-L114