### PR TITLE
Add TEMPLATEPATH, STYLESHEETPATH, and WP_DEFAULT_THEME constants

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -54,3 +54,8 @@ define('EP_AUTHORS', 2048);
 define('EP_PAGES', 4096);
 define('EP_ALL_ARCHIVES', EP_DATE | EP_YEAR | EP_MONTH | EP_DAY | EP_CATEGORIES | EP_TAGS | EP_AUTHORS);
 define('EP_ALL', EP_PERMALINK | EP_ATTACHMENT | EP_ROOT | EP_COMMENTS | EP_SEARCH | EP_PAGES | EP_ALL_ARCHIVES);
+
+// Templating-related WordPress constants.
+define( 'STYLESHEETPATH', '/app/wp-content/themes/child/' );
+define( 'TEMPLATEPATH', '/app/wp-content/themes/parent/' );
+define( 'WP_DEFAULT_THEME', 'twentytwentythree' );


### PR DESCRIPTION
See [`wp_templating_constants()`](https://github.com/WordPress/wordpress-develop/blob/dbbc9bcf98787fd77fd920df84cc9bbc69974b0a/src/wp-includes/default-constants.php#L387-L420)