### PR TITLE
Add dynamic return type extension for `get_post_types`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -107,6 +107,10 @@ services:
         class: SzepeViktor\PHPStan\WordPress\AssertNotWpErrorTypeSpecifyingExtension
         tags:
             - phpstan.typeSpecifier.methodTypeSpecifyingExtension
+    -
+        class: SzepeViktor\PHPStan\WordPress\GetPostTypesDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
 rules:
     - SzepeViktor\PHPStan\WordPress\HookCallbackRule
     - SzepeViktor\PHPStan\WordPress\HookDocsRule

--- a/src/GetPostTypesDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostTypesDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+/**
+ * The `get_post_types` function returns different results based on the
+ * arguments passed to the function.
+ *
+ *
+ */
+class GetPostTypesDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported( FunctionReflection $functionReflection ): bool
+    {
+        return $functionReflection->getName() === 'get_post_types';
+    }
+
+    /**
+     * - Return `string[]` if default or `$output = 'names'`.
+     * - Return `WP_Post_Type[]` if `$output` is anything but 'names';
+     *
+     * @link https://developer.wordpress.org/reference/functions/get_post_types/#parameters
+     *
+     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
+     */
+    public function getTypeFromFunctionCall( FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope ): ?Type
+    {
+        $args = $functionCall->getArgs();
+
+        if (count($args) < 2) {
+            return new ArrayType(new IntegerType(), new StringType());
+        }
+
+        $argumentType = $scope->getType($args[1]->value);
+        if (count($argumentType->getConstantStrings()) === 1) {
+            if ($argumentType->getConstantStrings()[0]->getValue() === 'names') {
+                return new ArrayType(new IntegerType(), new StringType());
+            }
+        }
+
+        return new ArrayType(new IntegerType(), new ObjectType('WP_Post_Type'));
+    }
+}

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -23,6 +23,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_posts.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post_types.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_sites.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/get_terms.php');
         yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');

--- a/tests/data/get_post_types.php
+++ b/tests/data/get_post_types.php
@@ -1,0 +1,12 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function PHPStan\Testing\assertType;
+
+assertType('array<int, string>', get_post_types());
+assertType('array<int, string>', get_post_types([]));
+assertType('array<int, string>', get_post_types([],'names'));
+assertType('array<int, WP_Post_Type>', get_post_types([],'objects'));


### PR DESCRIPTION
Introduce GetPostTypesDynamicFunctionReturnTypeExtension service

The `get_post_types` function return either and array of `string` or an array of `WP_Post_Type` depending on the passed arguments.

https://developer.wordpress.org/reference/functions/get_post_types/#return