### PR TITLE
Remove deprecated `instanceof` from `wp_parse_url` extension

### DIFF
--- a/tests/data/wp_parse_url.php
+++ b/tests/data/wp_parse_url.php
@@ -8,20 +8,8 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
+use function wp_parse_url;
 use function PHPStan\Testing\assertType;
-use function wp_clear_scheduled_hook;
-use function wp_insert_attachment;
-use function wp_insert_category;
-use function wp_insert_link;
-use function wp_insert_post;
-use function wp_reschedule_event;
-use function wp_schedule_event;
-use function wp_schedule_single_event;
-use function wp_set_comment_status;
-use function wp_unschedule_event;
-use function wp_unschedule_hook;
-use function wp_update_comment;
-use function wp_update_post;
 
 /** @var int $integer */
 $integer = doFoo();
@@ -61,3 +49,11 @@ assertType('int|false|null', $value);
 
 $value = wp_parse_url($string);
 assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $value);
+
+/** @var 'http://def.abc'|'https://example.com' $union */
+$union = $union;
+assertType("array{scheme: 'http', host: 'def.abc'}|array{scheme: 'https', host: 'example.com'}", wp_parse_url($union));
+
+/** @var 'http://def.abc#fragment1'|'https://example.com#fragment2' $union */
+$union = $union;
+assertType("'fragment1'|'fragment2'", wp_parse_url($union, PHP_URL_FRAGMENT));


### PR DESCRIPTION
Part of #149