### PR TITLE
Remove deprecated `instanceof`

### DIFF
--- a/src/GetPostsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostsDynamicFunctionReturnTypeExtension.php
@@ -16,7 +16,6 @@ use PHPStan\Type\Type;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\UnionType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\Constant\ConstantStringType;
 
@@ -55,7 +54,6 @@ class GetPostsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
         }
 
         foreach ($argumentType->getConstantArrays() as $array) {
-
             if ($array->hasOffsetValueType(new ConstantStringType('fields'))->no()) {
                 $returnTypes[] = self::getObjectType();
                 continue;
@@ -66,15 +64,15 @@ class GetPostsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
                 continue;
             }
 
-            $fieldsValueType = $array->getOffsetValueType(new ConstantStringType('fields'));
-            $constantFieldsValueTypes = $fieldsValueType->getConstantStrings();
+            $fieldsValueTypes = $array->getOffsetValueType(new ConstantStringType('fields'))->getConstantStrings();
 
-            if ($fieldsValueType instanceof UnionType && count($fieldsValueType->getTypes()) !== count($constantFieldsValueTypes)) {
+            if (count($fieldsValueTypes) === 0) {
                 $returnTypes[] = self::getIndeterminedType();
+                continue;
             }
 
-            foreach ($constantFieldsValueTypes as $constantFieldsValueType) {
-                switch ($constantFieldsValueType->getValue()) {
+            foreach ($fieldsValueTypes as $fieldsValueType) {
+                switch ($fieldsValueType->getValue()) {
                     case 'id=>parent':
                     case 'ids':
                         $returnTypes[] = self::getIntType();

--- a/src/GetPostsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostsDynamicFunctionReturnTypeExtension.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress;
 
+use WP_Post;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
@@ -15,8 +16,11 @@ use PHPStan\Type\Type;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\Constant\ConstantStringType;
+
+use function count;
 
 class GetPostsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
@@ -36,43 +40,64 @@ class GetPostsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
 
         // Called without arguments
         if (count($args) === 0) {
-            return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));
+            return self::getObjectType();
         }
 
         $argumentType = $scope->getType($args[0]->value);
+        $returnTypes = [];
 
-        // Called with an array argument
-        if ($argumentType instanceof ConstantArrayType) {
-            foreach ($argumentType->getKeyTypes() as $index => $key) {
-                if (! $key instanceof ConstantStringType || $key->getValue() !== 'fields') {
-                    continue;
-                }
+        foreach ($argumentType->getArrays() as $array) {
+            if (!$array->isConstantArray()->yes()) {
+                $returnTypes[] = self::getIndeterminedType();
+                continue;
+            }
 
-                $fieldsType = $argumentType->getValueTypes()[$index];
-                if ($fieldsType instanceof ConstantStringType) {
-                    $fields = $fieldsType->getValue();
+            if ($array->hasOffsetValueType(new ConstantStringType('fields'))->no()) {
+                $returnTypes[] = self::getObjectType();
+                continue;
+            }
+
+            if ($array->hasOffsetValueType(new ConstantStringType('fields'))->maybe()) {
+                $returnTypes[] = self::getIndeterminedType();
+                continue;
+            }
+
+            $fieldsValueType = $array->getOffsetValueType(new ConstantStringType('fields'));
+            $constantFieldsValueTypes = $fieldsValueType->getConstantStrings();
+
+            if ($fieldsValueType instanceof UnionType && count($fieldsValueType->getTypes()) !== count($constantFieldsValueTypes)) {
+                $returnTypes[] = self::getIndeterminedType();
+            }
+
+            foreach ($constantFieldsValueTypes as $constantFieldsValueType) {
+                switch ($constantFieldsValueType->getValue()) {
+                    case 'id=>parent':
+                    case 'ids':
+                        $returnTypes[] = self::getIntType();
+                        break;
+                    default:
+                        $returnTypes[] = self::getObjectType();
                 }
-                break;
             }
         }
-        // Called with a string argument
-        if ($argumentType instanceof ConstantStringType) {
-            parse_str($argumentType->getValue(), $variables);
-            $fields = $variables['fields'] ?? 'all';
-        }
+        return TypeCombinator::union(...$returnTypes);
+    }
 
-        // Without constant argument return default return type
-        if (! isset($fields)) {
-            return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));
-        }
+    private static function getIntType(): Type
+    {
+        return new ArrayType(new IntegerType(), new IntegerType());
+    }
 
-        switch ($fields) {
-            case 'id=>parent':
-            case 'ids':
-                return new ArrayType(new IntegerType(), new IntegerType());
-            case 'all':
-            default:
-                return new ArrayType(new IntegerType(), new ObjectType('WP_Post'));
-        }
+    private static function getObjectType(): Type
+    {
+        return new ArrayType(new IntegerType(), new ObjectType(WP_Post::class));
+    }
+
+    private static function getIndeterminedType(): Type
+    {
+        return TypeCombinator::union(
+            new ArrayType(new IntegerType(), new ObjectType(WP_Post::class)),
+            new ArrayType(new IntegerType(), new IntegerType()),
+        );
     }
 }

--- a/src/GetPostsDynamicFunctionReturnTypeExtension.php
+++ b/src/GetPostsDynamicFunctionReturnTypeExtension.php
@@ -46,11 +46,15 @@ class GetPostsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynami
         $argumentType = $scope->getType($args[0]->value);
         $returnTypes = [];
 
-        foreach ($argumentType->getArrays() as $array) {
-            if (!$array->isConstantArray()->yes()) {
-                $returnTypes[] = self::getIndeterminedType();
-                continue;
-            }
+        if ($argumentType->isConstantArray()->no()) {
+            return self::getIndeterminedType();
+        }
+
+        if ($argumentType->isConstantArray()->maybe()) {
+            $returnTypes[] = self::getIndeterminedType();
+        }
+
+        foreach ($argumentType->getConstantArrays() as $array) {
 
             if ($array->hasOffsetValueType(new ConstantStringType('fields'))->no()) {
                 $returnTypes[] = self::getObjectType();

--- a/tests/data/get_posts.php
+++ b/tests/data/get_posts.php
@@ -55,3 +55,12 @@ assertType('array<int, int|WP_Post>', get_posts(['fields' => $union]));
 
 $union = $_GET['foo'] ? (string)$_GET['string'] : 'id=>parent';
 assertType('array<int, int|WP_Post>', get_posts(['fields' => $union]));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|WP_Post>', get_posts([$union => '']));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|WP_Post>', get_posts([$union => 'ids']));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|WP_Post>', get_posts([$union => 'id=>parent']));

--- a/tests/data/get_posts.php
+++ b/tests/data/get_posts.php
@@ -46,3 +46,12 @@ assertType('array<int, int|WP_Post>', get_posts($union));
 
 $union = $_GET['foo'] ? (array)$_GET['array'] : ['fields' => 'id=>parent'];
 assertType('array<int, int|WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : '';
+assertType('array<int, int|WP_Post>', get_posts(['fields' => $union]));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'ids';
+assertType('array<int, int|WP_Post>', get_posts(['fields' => $union]));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'id=>parent';
+assertType('array<int, int|WP_Post>', get_posts(['fields' => $union]));

--- a/tests/data/get_posts.php
+++ b/tests/data/get_posts.php
@@ -7,6 +7,42 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 use function PHPStan\Testing\assertType;
 
 assertType('array<int, WP_Post>', get_posts());
-assertType('array<int, WP_Post>', get_posts(['fields' => 'all']));
+assertType('array<int, WP_Post>', get_posts(['key' => 'value']));
+assertType('array<int, WP_Post>', get_posts(['fields' => '']));
 assertType('array<int, int>', get_posts(['fields' => 'ids']));
 assertType('array<int, int>', get_posts(['fields' => 'id=>parent']));
+assertType('array<int, WP_Post>', get_posts(['fields' => 'Hello']));
+
+// Non constant array
+assertType('array<int, int|WP_Post>', get_posts((array)$_GET['array']));
+
+// Unions
+$union = $_GET['foo'] ? ['key' => 'value'] : ['some' => 'thing'];
+assertType('array<int, WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? ['key' => 'value'] : ['fields' => 'ids'];
+assertType('array<int, int|WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? ['key' => 'value'] : ['fields' => ''];
+assertType('array<int, WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? ['key' => 'value'] : ['fields' => 'id=>parent'];
+assertType('array<int, int|WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? ['fields' => ''] : ['fields' => 'ids'];
+assertType('array<int, int|WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? ['fields' => ''] : ['fields' => 'id=>parent'];
+assertType('array<int, int|WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? ['fields' => 'ids'] : ['fields' => 'id=>parent'];
+assertType('array<int, int>', get_posts($union));
+
+$union = $_GET['foo'] ? (array)$_GET['array'] : ['fields' => ''];
+assertType('array<int, int|WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? (array)$_GET['array'] : ['fields' => 'ids'];
+assertType('array<int, int|WP_Post>', get_posts($union));
+
+$union = $_GET['foo'] ? (array)$_GET['array'] : ['fields' => 'id=>parent'];
+assertType('array<int, int|WP_Post>', get_posts($union));

--- a/tests/data/get_posts.php
+++ b/tests/data/get_posts.php
@@ -13,7 +13,7 @@ assertType('array<int, int>', get_posts(['fields' => 'ids']));
 assertType('array<int, int>', get_posts(['fields' => 'id=>parent']));
 assertType('array<int, WP_Post>', get_posts(['fields' => 'Hello']));
 
-// Non constant array
+// Nonconstant array
 assertType('array<int, int|WP_Post>', get_posts((array)$_GET['array']));
 
 // Unions


### PR DESCRIPTION
What I was wondering when updating this extension. I can have a non constant array that has a key `'fields'`.
```php
// Non constant array with fields first
$array = [
    'fields' => 'ids',
    $_GET['foo'] => $_GET['bar'],
];
assertType('array<int, int|WP_Post>', get_posts($array));

// Non constant array with fields last
$array = [
    $_GET['foo'] => $_GET['bar'],
    'fields' => 'ids',
];
assertType('array<int, int>', get_posts($array));
```

`get_post($array)` with the fields first case returns `array<int, int|WP_Post>` because `$_GET['foo']` may be `'fields'` and overwrite `'ids'`. `get_post($array)` with the fields last case returns  `array<int, int>` as `'fields'` is not affected by `$_GET['foo']` and hence will  be `'ids'`. With limited PHPStan knowledge, I was not able to find a way to check the order of `$_GET['foo']` and `'fields'` or more specifically to check whether there is a non constant key after the fields key.

Is there a simple way to check the order of the keys with PHPStan?

Part of #149