### PR TITLE
Remove deprecated `instanceof`

### DIFF
--- a/tests/data/get_terms.php
+++ b/tests/data/get_terms.php
@@ -6,32 +6,13 @@ namespace SzepeViktor\PHPStan\WordPress\Tests;
 
 use function PHPStan\Testing\assertType;
 
-$fields = $_GET['fields'] ?? 'all';
-$key = $_GET['key'] ?? 'fields';
-$count = ! empty( $_GET['count'] );
-
 // Default argument values
 assertType('array<int, WP_Term>|WP_Error', get_terms());
 assertType('array<int, WP_Term>|WP_Error', get_terms([]));
 
-// Unknown values
-assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$fields]));
-assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['foo'=>'bar','fields'=>$fields]));
-assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['count'=>$count]));
-assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['count'=>$count,'fields'=>'ids']));
-assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$fields,'count'=>false]));
-
-// Unknown keys
-assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$key=>'all']));
-assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['foo'=>'bar',$key=>'all']));
-
 // Requesting a count
 assertType('string|WP_Error', get_terms(['fields'=>'count']));
 assertType('string|WP_Error', get_terms(['foo'=>'bar','fields'=>'count']));
-assertType('string|WP_Error', get_terms(['count'=>true]));
-assertType('string|WP_Error', get_terms(['foo'=>'bar','count'=>true]));
-assertType('string|WP_Error', get_terms(['fields'=>'ids','count'=>true]));
-assertType('string|WP_Error', get_terms(['fields'=>$fields,'count'=>true]));
 
 // Requesting names or slugs
 assertType('array<int, string>|WP_Error', get_terms(['fields'=>'names']));
@@ -44,7 +25,7 @@ assertType('array<int, int>|WP_Error', get_terms(['fields'=>'ids']));
 assertType('array<int, int>|WP_Error', get_terms(['fields'=>'tt_ids']));
 
 // Requesting parent IDs (numeric strings)
-assertType('array<int, string>|WP_Error', get_terms(['fields'=>'id=>parent']));
+assertType('array<int, numeric-string>|WP_Error', get_terms(['fields'=>'id=>parent']));
 
 // Requesting objects
 assertType('array<int, WP_Term>|WP_Error', get_terms(['fields'=>'all']));
@@ -60,3 +41,73 @@ assertType('array<int, WP_Term>|WP_Error', wp_get_object_terms(123, 'category'))
 assertType('array<int, WP_Term>|WP_Error', wp_get_post_categories(123));
 assertType('array<int, WP_Term>|WP_Error', wp_get_post_tags(123));
 assertType('array<int, WP_Term>|WP_Error', wp_get_post_terms(123, 'category'));
+
+// Unions - nonexhaustive list
+$fields = $_GET['foo'] ? (string)$_GET['string'] : 'all';
+$key = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+$count = ! empty( $_GET['count'] );
+
+$union = $_GET['foo'] ? ['key'=>'value'] : ['some'=>'thing'];
+assertType('array<int, WP_Term>|WP_Error', get_terms($union));
+
+$union = $_GET['foo'] ? ['key'=>'value'] : ['fields'=>'count'];
+assertType('array<int, WP_Term>|string|WP_Error', get_terms($union));
+
+$union = $_GET['foo'] ? ['key'=>'value'] : ['fields'=>'names'];
+assertType('array<int, string|WP_Term>|WP_Error', get_terms($union));
+
+$union = $_GET['foo'] ? ['key'=>'value'] : ['fields'=>'ids'];
+assertType('array<int, int|WP_Term>|WP_Error', get_terms($union));
+
+$union = $_GET['foo'] ? ['key'=>'value'] : ['fields'=>'id=>parent'];
+assertType('array<int, WP_Term|numeric-string>|WP_Error', get_terms($union));
+
+$union = $_GET['foo'] ? ['key'=>'value'] : ['fields'=>'all'];
+assertType('array<int, WP_Term>|WP_Error', get_terms($union));
+
+$union = $_GET['foo'] ? ['fields'=>'names'] : ['fields'=>'count'];
+assertType('array<int, string>|string|WP_Error', get_terms($union));
+
+$union = $_GET['foo'] ? ['fields'=>'id=>parent'] : ['fields'=>'ids'];
+assertType('array<int, int|numeric-string>|WP_Error', get_terms($union));
+
+$union = $_GET['foo'] ? ['fields'=>'all'] : ['fields'=>'count'];
+assertType('array<int, WP_Term>|string|WP_Error', get_terms($union));
+
+// Unions with unknown fields value
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'all';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$union]));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'ids';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$union]));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'id=>parent';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$union]));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'count';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$union]));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'names';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['fields'=>$union]));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'all';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['foo'=>'bar','fields'=>$union]));
+
+// Unions with unknown fields key - not supported
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$union=>'all']));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$union=>'ids']));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$union=>'id=>parent']));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$union=>'count']));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms([$union=>'names']));
+
+$union = $_GET['foo'] ? (string)$_GET['string'] : 'fields';
+assertType('array<int, int|string|WP_Term>|string|WP_Error', get_terms(['foo'=>'bar',$union=>'all']));


### PR DESCRIPTION
I also removed dealing with the `$count` argument which was deprecated in WP 4.5. In WP 4.5 also the position of the `$args` argument changed. Given  we use `'get_terms' => 0,` we're not supporting WP versions lower than 4.5. Hence `$count` had no effect.

Travis should be going green again soon. This was the last extension with deprecation notices.

Part of #149