### PR TITLE
Fix _get_list_table extension

### DIFF
--- a/src/GetListTableDynamicFunctionReturnTypeExtension.php
+++ b/src/GetListTableDynamicFunctionReturnTypeExtension.php
@@ -18,6 +18,26 @@ use PHPStan\Type\TypeCombinator;
 
 class GetListTableDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
+    private const CORE_CLASSES = [
+        'WP_Posts_List_Table',
+        'WP_Media_List_Table',
+        'WP_Terms_List_Table',
+        'WP_Users_List_Table',
+        'WP_Comments_List_Table',
+        'WP_Post_Comments_List_Table',
+        'WP_Links_List_Table',
+        'WP_Plugin_Install_List_Table',
+        'WP_Themes_List_Table',
+        'WP_Theme_Install_List_Table',
+        'WP_Plugins_List_Table',
+        'WP_Application_Passwords_List_Table',
+        'WP_MS_Sites_List_Table',
+        'WP_MS_Users_List_Table',
+        'WP_MS_Themes_List_Table',
+        'WP_Privacy_Data_Export_Requests_List_Table',
+        'WP_Privacy_Data_Removal_Requests_List_Table',
+    ];
+
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
         return $functionReflection->getName() === '_get_list_table';
@@ -30,7 +50,7 @@ class GetListTableDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
 
         // Called without $class argument
         if (count($args) < 1) {
-            return new ConstantBooleanType(false);
+            return null;
         }
 
         $argumentType = $scope->getType($args[0]->value);
@@ -40,9 +60,11 @@ class GetListTableDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dy
             return null;
         }
 
-        $types = [new ConstantBooleanType(false)];
+        $types = [];
         foreach ($argumentType->getConstantStrings() as $constantString) {
-            $types[] = new ObjectType($constantString->getValue());
+            $types[] = in_array($constantString->getValue(), self::CORE_CLASSES, true)
+                ? new ObjectType($constantString->getValue())
+                : new ConstantBooleanType(false);
         }
 
         return TypeCombinator::union(...$types);

--- a/tests/data/_get_list_table.php
+++ b/tests/data/_get_list_table.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
+use function _get_list_table;
 use function PHPStan\Testing\assertType;
 
 // Known class name
-assertType('WP_Posts_List_Table|false', _get_list_table('WP_Posts_List_Table'));
-assertType('Unknown_Table|false', _get_list_table('Unknown_Table'));
+assertType('WP_Posts_List_Table', _get_list_table('WP_Posts_List_Table'));
+assertType('false', _get_list_table('Unknown_Table'));
 
 // Unknown class name
 assertType('WP_List_Table|false', _get_list_table($_GET['foo']));


### PR DESCRIPTION
Fixes the dynamic return type extension for `_get_list_table()`.

According to the [docs](https://developer.wordpress.org/reference/functions/_get_list_table/), `_get_list_table()` returns a (known or unknown) child class of WP_List_Table or WP_List_Table class itself if the passed argument is a WP_List_Table (child) class name, and `false` otherwise.

As the class name is filterable any WP_List_Table child class maybe returned... We can either assume that in most cases this filtered is not used and return a `WP_Posts_List_Table` when the argument is `WP_Posts_List_Table` and risk that this is incorrect (the previous functionality and the current approach) or we can simply return a `WP_List_Table` which will be correct but less precise.