### PR TITLE
Fix dynamic return type extension for `wp_die()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
-        "phpstan/phpstan": "^1.10.0",
+        "phpstan/phpstan": "^1.10.30",
         "symfony/polyfill-php73": "^1.12.0"
     },
     "require-dev": {

--- a/src/WpDieDynamicFunctionReturnTypeExtension.php
+++ b/src/WpDieDynamicFunctionReturnTypeExtension.php
@@ -14,7 +14,7 @@ use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VoidType;
-use PHPStan\Type\NeverType;
+use PHPStan\Type\NonAcceptingNeverType;
 
 class WpDieDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
@@ -30,7 +30,7 @@ class WpDieDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFu
 
         // Called without $args parameter
         if (count($args) < 3) {
-            return new NeverType();
+            return new NonAcceptingNeverType();
         }
 
         $argType = $scope->getType($args[2]->value);
@@ -42,12 +42,12 @@ class WpDieDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFu
 
         // Return never if the key 'exit' is not set.
         if (! $argType->hasOffsetValueType(new ConstantStringType('exit'))->yes()) {
-            return new NeverType();
+            return new NonAcceptingNeverType();
         }
 
         // Note WP's wp_die handlers do lazy comparison
         return $argType->getOffsetValueType(new ConstantStringType('exit'))->toBoolean()->isTrue()->yes()
-            ? new NeverType()
+            ? new NonAcceptingNeverType()
             : new VoidType();
     }
 }

--- a/tests/data/wp_die.php
+++ b/tests/data/wp_die.php
@@ -9,6 +9,8 @@ use function PHPStan\Testing\assertType;
 /** @var array $array */
 $array = null;
 
+assertType('*NEVER*', wp_die());
+assertType('*NEVER*', wp_die(''));
 assertType('*NEVER*', wp_die('', ''));
 assertType('*NEVER*', wp_die('', '', ['exit' => true]));
 assertType('void', wp_die('', '', ['exit' => false]));

--- a/tests/data/wp_die.php
+++ b/tests/data/wp_die.php
@@ -9,9 +9,9 @@ use function PHPStan\Testing\assertType;
 /** @var array $array */
 $array = null;
 
-assertType('*NEVER*', wp_die());
-assertType('*NEVER*', wp_die(''));
-assertType('*NEVER*', wp_die('', ''));
-assertType('*NEVER*', wp_die('', '', ['exit' => true]));
+assertType('never', wp_die());
+assertType('never', wp_die(''));
+assertType('never', wp_die('', ''));
+assertType('never', wp_die('', '', ['exit' => true]));
 assertType('void', wp_die('', '', ['exit' => false]));
 assertType('void', wp_die('', '', $array));


### PR DESCRIPTION
Fixes #203
Adds missing tests (https://github.com/szepeviktor/phpstan-wordpress/issues/203#issuecomment-1764619896)