### PR TITLE
Fix dynamic call to static method

### DIFF
--- a/tests/AssertMethodTypeSpecifyingExtensionTest.php
+++ b/tests/AssertMethodTypeSpecifyingExtensionTest.php
@@ -12,8 +12,8 @@ class AssertMethodTypeSpecifyingExtensionTest extends \PHPStan\Testing\TypeInfer
     public function dataFileAsserts(): iterable
     {
         // Path to a file with actual asserts of expected types:
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/assert_wp_error.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/assert_not_wp_error.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/assert_wp_error.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/assert_not_wp_error.php');
     }
 
     /**

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -12,27 +12,27 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
     public function dataFileAsserts(): iterable
     {
         // Path to a file with actual asserts of expected types:
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/_get_list_table.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/apply_filters.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/current_time.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/echo_key.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/echo_parameter.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/esc_sql.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_comment.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_post.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_posts.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_sites.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/get_terms.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/has_filter.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/term_exists.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_parse_url.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_die.php');
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/wp_theme_get.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/_get_list_table.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/apply_filters.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/current_time.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/echo_key.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/echo_parameter.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/esc_sql.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/get_comment.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/get_object_taxonomies.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/get_permalink.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/get_post.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/get_posts.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/get_sites.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/get_terms.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/has_filter.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/mysql2date.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/term_exists.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/wp_parse_url.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/wp_die.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/wp_theme_get.php');
     }
 
     /**


### PR DESCRIPTION
The `\PHPStan\Testing\TypeInferenceTestCase::gatherAssertTypes()` method is called statically. See the implementation in the PHPStan source code here: [PHPStan TypeInferenceTestCase.php line 118-120](https://github.com/phpstan/phpstan-src/blob/6bdc25a944690839507a8ca96d33ec7c51660f3f/src/Testing/TypeInferenceTestCase.php#L118-L120).

We have updated the minimum required version from 1.10.0 to 1.10.31. In version 1.10.0, it was still called dynamically, as can be seen here: [PHPStan TypeInferenceTestCase.php line 81-83](https://github.com/phpstan/phpstan-src/blob/2ca979344d7750dee065ffb6c43af6236f398241/src/Testing/TypeInferenceTestCase.php#L81-L83)."