### PR TITLE
Add WP_LANG_DIR constant

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,6 +12,7 @@ define('WP_PLUGIN_DIR', './');
 define('WPMU_PLUGIN_DIR', './');
 define('EMPTY_TRASH_DAYS', 30 * 86400);
 define('SCRIPT_DEBUG', false);
+define('WP_LANG_DIR', './');
 
 // Constants for expressing human-readable intervals.
 define('MINUTE_IN_SECONDS', 60);


### PR DESCRIPTION
Defined in `wp_set_lang_dir()`.

There is no function to read this constant.

Related:

* #193 