### PR TITLE
Add WP_CONTENT_DIR constant

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,6 +13,7 @@ define('WPMU_PLUGIN_DIR', './');
 define('EMPTY_TRASH_DAYS', 30 * 86400);
 define('SCRIPT_DEBUG', false);
 define('WP_LANG_DIR', './');
+define('WP_CONTENT_DIR', './');
 
 // Constants for expressing human-readable intervals.
 define('MINUTE_IN_SECONDS', 60);


### PR DESCRIPTION
There is no core function to read this constant. Core reads the constant directly.

See https://github.com/szepeviktor/phpstan-wordpress/pull/212#issuecomment-1994556934