### PR TITLE
Add WP_DEBUG_DISPLAY constant

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 define('ABSPATH', './');
 define('WP_DEBUG', true);
 define('WP_DEBUG_LOG', true);
+define('WP_DEBUG_DISPLAY', true);
 define('WP_PLUGIN_DIR', './');
 define('WPMU_PLUGIN_DIR', './');
 define('EMPTY_TRASH_DAYS', 30 * 86400);

--- a/extension.neon
+++ b/extension.neon
@@ -126,6 +126,7 @@ parameters:
     dynamicConstantNames:
         - WP_DEBUG
         - WP_DEBUG_LOG
+        - WP_DEBUG_DISPLAY
         - EMPTY_TRASH_DAYS
         - WP_CLI
         - COOKIE_DOMAIN


### PR DESCRIPTION
As with the `WP_DEBUG` constant, there is no function to read the [`WP_DEBUG_DISPLAY`](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/#wp_debug_display) constant. Core looks at the constant directly.