### PR TITLE
Fix #221

### DIFF
--- a/tests/HookCallbackRuleTest.php
+++ b/tests/HookCallbackRuleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
-use PHPStan\Rules\RuleLevelHelper;
 use SzepeViktor\PHPStan\WordPress\HookCallbackRule;
 
 /**
@@ -14,11 +13,8 @@ class HookCallbackRuleTest extends \PHPStan\Testing\RuleTestCase
 {
     protected function getRule(): \PHPStan\Rules\Rule
     {
-        /** @var \PHPStan\Rules\RuleLevelHelper */
-        $ruleLevelHelper = self::getContainer()->getByType(RuleLevelHelper::class);
-
         // getRule() method needs to return an instance of the tested rule
-        return new HookCallbackRule($ruleLevelHelper);
+        return new HookCallbackRule();
     }
 
     // phpcs:ignore NeutronStandard.Functions.LongFunction.LongFunction

--- a/tests/HookCallbackRuleTest.php
+++ b/tests/HookCallbackRuleTest.php
@@ -116,6 +116,10 @@ class HookCallbackRuleTest extends \PHPStan\Testing\RuleTestCase
                     'Action callback returns mixed but should not return anything.',
                     99,
                 ],
+                [
+                    'Action callback returns null but should not return anything.',
+                    102,
+                ],
             ]
         );
     }

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -221,7 +221,6 @@ add_filter('filter', '__return_null');
 add_filter('filter', '__return_empty_array');
 add_filter('filter', '__return_empty_string');
 add_filter('filter', __NAMESPACE__ . '\\return_value_mixed');
-add_filter('filter', __NAMESPACE__ . '\\return_value_untyped');
 add_filter('filter', __NAMESPACE__ . '\\return_value_mixed_union');
 add_filter('filter', __NAMESPACE__ . '\\return_value_documented');
 add_filter('filter', __NAMESPACE__ . '\\return_value_untyped');

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -98,6 +98,9 @@ add_action('action', '__return_false', 10, 2);
 // Action callback returns mixed but should not return anything.
 add_action('action', __NAMESPACE__ . '\\return_value_mixed');
 
+// Action callback returns null but should not return anything.
+add_action('action', '__return_null');
+
 /**
  * Incorrect usage that's handled by PHPStan:
  *


### PR DESCRIPTION
#221 was caused by the `VoidType` accepting `NullType` from PHPStan version 1.10.50 onwards (see [this commit](https://github.com/phpstan/phpstan-src/commit/40c8fb2266f040158fb811ac13b21a3e179c022a)).

This PR fixes #221 by using `isVoid()` to check for `VoidType`. `isVoid()` does not accept `NullType`.

Additionally, this PR adds a test for action callbacks that return `null`. Before this fix, the additional test was failing as well for the same reason.

Related: #222 