### PR TITLE
Allow returning null from a callback

### DIFF
--- a/src/HookCallbackRule.php
+++ b/src/HookCallbackRule.php
@@ -212,7 +212,7 @@ class HookCallbackRule implements \PHPStan\Rules\Rule
     {
         $returnType = $callbackAcceptor->getReturnType();
 
-        if ($returnType instanceof MixedType) {
+        if ($returnType instanceof MixedType || $returnType->isNull()->yes()) {
             return;
         }
 

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -16,8 +16,8 @@ use function add_action;
 // Filter callback return statement is missing.
 add_filter('filter', function() {});
 
-// Filter callback return statement is missing.
-add_filter('filter', function() {});
+// Filter callback returns void.
+add_filter('filter', function() { return; });
 
 // Filter callback return statement is missing.
 add_filter('filter', function(array $classes) {});
@@ -153,6 +153,10 @@ add_filter('filter', __NAMESPACE__ . '\\no_return_value_untyped');
 
 add_filter('filter', function() {
     return 123;
+}, 10, 0);
+add_filter('filter', function() {
+    // null can be a valid return value, unfortunately.
+    return null;
 }, 10, 0);
 add_filter('filter', function() {
     // We're allowing 0 parameters when `$accepted_args` is default value of 1.


### PR DESCRIPTION
Fixes #221

Attempt to distinguish between returning void and null from a callback.

Unfortunately, some filters are expecting a null value. See an example in the WooCommerce repository here:

https://github.com/woocommerce/woocommerce/blob/7f657cca539af928a58b05716423971b737da91f/plugins/woocommerce/includes/admin/class-wc-admin-settings.php#L934-L938
