### PR TITLE
Fix/update extension for wp_parse_url

### DIFF
--- a/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
@@ -66,6 +66,8 @@ final class WpParseUrlFunctionDynamicReturnTypeExtension implements \PHPStan\Typ
 
         $this->cacheReturnTypes();
 
+        $componentType = new ConstantIntegerType(-1);
+
         if (count($functionCall->getArgs()) > 1) {
             $componentType = $scope->getType($functionCall->getArgs()[1]->value);
 
@@ -78,8 +80,6 @@ final class WpParseUrlFunctionDynamicReturnTypeExtension implements \PHPStan\Typ
             if (! $componentType instanceof ConstantIntegerType) {
                 return $this->createAllComponentsReturnType();
             }
-        } else {
-            $componentType = new ConstantIntegerType(-1);
         }
 
         $urlType = $scope->getType($functionCall->getArgs()[0]->value);

--- a/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
@@ -145,13 +145,13 @@ final class WpParseUrlFunctionDynamicReturnTypeExtension implements \PHPStan\Typ
             return;
         }
 
-        $string = new StringType();
+        $stringType = new StringType();
         $port = IntegerRangeType::fromInterval(0, 65535);
-        $false = new ConstantBooleanType(false);
-        $null = new NullType();
+        $falseType = new ConstantBooleanType(false);
+        $nullType = new NullType();
 
-        $stringOrFalseOrNull = TypeCombinator::union($string, $false, $null);
-        $portOrFalseOrNull = TypeCombinator::union($port, $false, $null);
+        $stringOrFalseOrNull = TypeCombinator::union($stringType, $falseType, $nullType);
+        $portOrFalseOrNull = TypeCombinator::union($port, $falseType, $nullType);
 
         $this->componentTypesPairedConstants = [
             PHP_URL_SCHEME => $stringOrFalseOrNull,
@@ -165,14 +165,14 @@ final class WpParseUrlFunctionDynamicReturnTypeExtension implements \PHPStan\Typ
         ];
 
         $this->componentTypesPairedStrings = [
-            'scheme' => $string,
-            'host' => $string,
+            'scheme' => $stringType,
+            'host' => $stringType,
             'port' => $port,
-            'user' => $string,
-            'pass' => $string,
-            'path' => $string,
-            'query' => $string,
-            'fragment' => $string,
+            'user' => $stringType,
+            'pass' => $stringType,
+            'path' => $stringType,
+            'query' => $stringType,
+            'fragment' => $stringType,
         ];
     }
 }

--- a/tests/data/wp_parse_url.php
+++ b/tests/data/wp_parse_url.php
@@ -30,7 +30,7 @@ $value = wp_parse_url('http://def.abc', -1);
 assertType("array{scheme: 'http', host: 'def.abc'}", $value);
 
 $value = wp_parse_url('http://def.abc', $integer);
-assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $value);
+assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|int<0, 65535>|string|false|null', $value);
 
 $value = wp_parse_url('http://def.abc', PHP_URL_FRAGMENT);
 assertType('null', $value);
@@ -45,10 +45,10 @@ $value = wp_parse_url($string, 9999);
 assertType('false', $value);
 
 $value = wp_parse_url($string, PHP_URL_PORT);
-assertType('int|false|null', $value);
+assertType('int<0, 65535>|false|null', $value);
 
 $value = wp_parse_url($string);
-assertType('array{scheme?: string, host?: string, port?: int, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $value);
+assertType('array{scheme?: string, host?: string, port?: int<0, 65535>, user?: string, pass?: string, path?: string, query?: string, fragment?: string}|false', $value);
 
 /** @var 'http://def.abc'|'https://example.com' $union */
 $union = $union;


### PR DESCRIPTION
This update to `WpParseUrlFunctionDynamicReturnTypeExtension` from [PHPStan's extension for `parse_url`](https://github.com/phpstan/phpstan-src/blob/877ff0a620dc407182e71955fbde8b6e081a15ce/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php) fixes an incorrect return type when the `$component` parameter is a non-constant integer. Additionally, the extension is now more specific about the port type.