### PR TITLE
Add data size constants

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -29,6 +29,10 @@ define('KB_IN_BYTES', 1024);
 define('MB_IN_BYTES', 1024 * KB_IN_BYTES);
 define('GB_IN_BYTES', 1024 * MB_IN_BYTES);
 define('TB_IN_BYTES', 1024 * GB_IN_BYTES);
+define('PB_IN_BYTES', 1024 * TB_IN_BYTES);
+define('EB_IN_BYTES', 1024 * PB_IN_BYTES);
+define('ZB_IN_BYTES', 1024 * EB_IN_BYTES);
+define('YB_IN_BYTES', 1024 * ZB_IN_BYTES);
 
 // wpdb method parameters.
 define('OBJECT', 'OBJECT');


### PR DESCRIPTION
These constants were added in WP 6.0.0:
- PB_IN_BYTES
- EB_IN_BYTES
- ZB_IN_BYTES
- YB_IN_BYTES