### PR TITLE
Remove return type extension for wp_dropdown_categories

### DIFF
--- a/src/EchoKeyDynamicFunctionReturnTypeExtension.php
+++ b/src/EchoKeyDynamicFunctionReturnTypeExtension.php
@@ -29,7 +29,6 @@ class EchoKeyDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynamic
     private const FUNCTIONS = [
         'get_search_form' => 0,
         'the_title_attribute' => 0,
-        'wp_dropdown_categories' => 0,
         'wp_dropdown_languages' => 0,
         'wp_dropdown_pages' => 0,
         'wp_dropdown_users' => 0,
@@ -89,7 +88,6 @@ class EchoKeyDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynamic
     /**
      * @see https://developer.wordpress.org/reference/functions/get_search_form/
      * @see https://developer.wordpress.org/reference/functions/the_title_attribute/
-     * @see https://developer.wordpress.org/reference/functions/wp_dropdown_categories/
      * @see https://developer.wordpress.org/reference/functions/wp_dropdown_languages/
      * @see https://developer.wordpress.org/reference/functions/wp_dropdown_pages/
      * @see https://developer.wordpress.org/reference/functions/wp_dropdown_users/

--- a/tests/data/echo_key.php
+++ b/tests/data/echo_key.php
@@ -9,7 +9,6 @@ use function PHPStan\Testing\assertType;
 // Default value of true
 assertType('void', get_search_form());
 assertType('void', the_title_attribute());
-assertType('void', wp_dropdown_categories());
 assertType('void', wp_dropdown_languages());
 assertType('void', wp_dropdown_pages());
 assertType('void', wp_dropdown_users());
@@ -28,7 +27,6 @@ assertType('void', wp_page_menu());
 $args = ['echo' => true];
 assertType('void', get_search_form($args));
 assertType('void', the_title_attribute($args));
-assertType('void', wp_dropdown_categories($args));
 assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_dropdown_pages($args));
 assertType('void', wp_dropdown_users($args));
@@ -45,7 +43,6 @@ assertType('void', wp_page_menu($args));
 
 // Explicit array key value of 1
 $args = ['echo' => 1];
-assertType('void', wp_dropdown_categories($args));
 assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_dropdown_pages($args));
 assertType('void', wp_dropdown_users($args));
@@ -58,7 +55,6 @@ assertType('void|false', wp_list_categories($args));
 $args = ['echo' => false];
 assertType('string', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
-assertType('string', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
 assertType('string', wp_dropdown_pages($args));
 assertType('string', wp_dropdown_users($args));
@@ -75,7 +71,6 @@ assertType('string', wp_page_menu($args));
 
 // Explicit array key value of 0
 $args = ['echo' => 0];
-assertType('string', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
 assertType('string', wp_dropdown_pages($args));
 assertType('string', wp_dropdown_users($args));
@@ -88,7 +83,6 @@ assertType('string|false', wp_list_categories($args));
 $args = ['echo' => $_GET['foo']];
 assertType('string|void', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_dropdown_pages($args));
 assertType('string|void', wp_dropdown_users($args));
@@ -106,7 +100,6 @@ assertType('string|void', wp_page_menu($args));
 // Explicit no query string value
 $args = 'akey=avalue';
 assertType('void', the_title_attribute($args));
-assertType('void', wp_dropdown_categories($args));
 assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_dropdown_pages($args));
 assertType('void', wp_dropdown_users($args));
@@ -123,7 +116,6 @@ assertType('void', wp_page_menu($args));
 // Explicit non empty non numeric query string value (includes 'true' & 'false')
 $args = 'echo=nonemptynonnumeric&akey=avalue';
 assertType('void', the_title_attribute($args));
-assertType('void', wp_dropdown_categories($args));
 assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_dropdown_pages($args));
 assertType('void', wp_dropdown_users($args));
@@ -140,7 +132,6 @@ assertType('void', wp_page_menu($args));
 // Explicit non zero numeric query string value
 $args = 'echo=1&akey=avalue';
 assertType('void', the_title_attribute($args));
-assertType('void', wp_dropdown_categories($args));
 assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_dropdown_pages($args));
 assertType('void', wp_dropdown_users($args));
@@ -157,7 +148,6 @@ assertType('void', wp_page_menu($args));
 // Explicit query string value of 0
 $args = 'echo=0&akey=avalue';
 assertType('string|void', the_title_attribute($args));
-assertType('string', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
 assertType('string', wp_dropdown_pages($args));
 assertType('string', wp_dropdown_users($args));
@@ -174,7 +164,6 @@ assertType('string', wp_page_menu($args));
 // Explicit empty query string value
 $args = 'echo=&akey=avalue';
 assertType('string|void', the_title_attribute($args));
-assertType('string', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
 assertType('string', wp_dropdown_pages($args));
 assertType('string', wp_dropdown_users($args));
@@ -192,7 +181,6 @@ assertType('string', wp_page_menu($args));
 $args = $_GET['foo'];
 assertType('string|void', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_dropdown_pages($args));
 assertType('string|void', wp_dropdown_users($args));
@@ -212,7 +200,6 @@ assertType('string|void', wp_page_menu($args));
 $args = '';
 assertType('string|void', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_categories($args));
 assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_dropdown_pages($args));
 assertType('string|void', wp_dropdown_users($args));


### PR DESCRIPTION
As documented, `wp_dropdown_categories()` always returns a string. See [lines 481-485 in wp-includes/category-template.php](https://github.com/WordPress/WordPress/blob/e25ffd14269ad6461aba63e3119ac5603502bf06/wp-includes/category-template.php#L481-L485).