### PR TITLE
Remove return type extension for wp_dropdown_languages

### DIFF
--- a/src/EchoKeyDynamicFunctionReturnTypeExtension.php
+++ b/src/EchoKeyDynamicFunctionReturnTypeExtension.php
@@ -29,7 +29,6 @@ class EchoKeyDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynamic
     private const FUNCTIONS = [
         'get_search_form' => 0,
         'the_title_attribute' => 0,
-        'wp_dropdown_languages' => 0,
         'wp_get_archives' => 0,
         'wp_list_authors' => 0,
         'wp_list_bookmarks' => 0,
@@ -54,7 +53,6 @@ class EchoKeyDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynamic
      */
     private const ALWAYS_VOID = [
         'the_title_attribute',
-        'wp_dropdown_languages',
         'wp_get_archives',
         'wp_list_comments',
     ];
@@ -85,7 +83,6 @@ class EchoKeyDynamicFunctionReturnTypeExtension implements \PHPStan\Type\Dynamic
     /**
      * @see https://developer.wordpress.org/reference/functions/get_search_form/
      * @see https://developer.wordpress.org/reference/functions/the_title_attribute/
-     * @see https://developer.wordpress.org/reference/functions/wp_dropdown_languages/
      * @see https://developer.wordpress.org/reference/functions/wp_get_archives/
      * @see https://developer.wordpress.org/reference/functions/wp_list_authors/
      * @see https://developer.wordpress.org/reference/functions/wp_list_bookmarks/

--- a/tests/data/echo_key.php
+++ b/tests/data/echo_key.php
@@ -9,7 +9,6 @@ use function PHPStan\Testing\assertType;
 // Default value of true
 assertType('void', get_search_form());
 assertType('void', the_title_attribute());
-assertType('void', wp_dropdown_languages());
 assertType('void', wp_get_archives());
 assertType('void', wp_list_authors());
 assertType('void', wp_list_bookmarks());
@@ -24,7 +23,6 @@ assertType('void', wp_page_menu());
 $args = ['echo' => true];
 assertType('void', get_search_form($args));
 assertType('void', the_title_attribute($args));
-assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_get_archives($args));
 assertType('void', wp_list_authors($args));
 assertType('void', wp_list_bookmarks($args));
@@ -37,7 +35,6 @@ assertType('void', wp_page_menu($args));
 
 // Explicit array key value of 1
 $args = ['echo' => 1];
-assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_get_archives($args));
 assertType('void', wp_list_bookmarks($args));
 assertType('void|false', wp_list_categories($args));
@@ -46,7 +43,6 @@ assertType('void|false', wp_list_categories($args));
 $args = ['echo' => false];
 assertType('string', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_get_archives($args));
 assertType('string', wp_list_authors($args));
 assertType('string', wp_list_bookmarks($args));
@@ -59,7 +55,6 @@ assertType('string', wp_page_menu($args));
 
 // Explicit array key value of 0
 $args = ['echo' => 0];
-assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_get_archives($args));
 assertType('string', wp_list_bookmarks($args));
 assertType('string|false', wp_list_categories($args));
@@ -68,7 +63,6 @@ assertType('string|false', wp_list_categories($args));
 $args = ['echo' => $_GET['foo']];
 assertType('string|void', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_get_archives($args));
 assertType('string|void', wp_list_authors($args));
 assertType('string|void', wp_list_bookmarks($args));
@@ -82,7 +76,6 @@ assertType('string|void', wp_page_menu($args));
 // Explicit no query string value
 $args = 'akey=avalue';
 assertType('void', the_title_attribute($args));
-assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_get_archives($args));
 assertType('void', wp_list_authors($args));
 assertType('void', wp_list_bookmarks($args));
@@ -95,7 +88,6 @@ assertType('void', wp_page_menu($args));
 // Explicit non empty non numeric query string value (includes 'true' & 'false')
 $args = 'echo=nonemptynonnumeric&akey=avalue';
 assertType('void', the_title_attribute($args));
-assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_get_archives($args));
 assertType('void', wp_list_authors($args));
 assertType('void', wp_list_bookmarks($args));
@@ -108,7 +100,6 @@ assertType('void', wp_page_menu($args));
 // Explicit non zero numeric query string value
 $args = 'echo=1&akey=avalue';
 assertType('void', the_title_attribute($args));
-assertType('void', wp_dropdown_languages($args));
 assertType('void', wp_get_archives($args));
 assertType('void', wp_list_authors($args));
 assertType('void', wp_list_bookmarks($args));
@@ -121,7 +112,6 @@ assertType('void', wp_page_menu($args));
 // Explicit query string value of 0
 $args = 'echo=0&akey=avalue';
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_get_archives($args));
 assertType('string', wp_list_authors($args));
 assertType('string', wp_list_bookmarks($args));
@@ -134,7 +124,6 @@ assertType('string', wp_page_menu($args));
 // Explicit empty query string value
 $args = 'echo=&akey=avalue';
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_get_archives($args));
 assertType('string', wp_list_authors($args));
 assertType('string', wp_list_bookmarks($args));
@@ -148,7 +137,6 @@ assertType('string', wp_page_menu($args));
 $args = $_GET['foo'];
 assertType('string|void', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_get_archives($args));
 assertType('string|void', wp_list_authors($args));
 assertType('string|void', wp_list_bookmarks($args));
@@ -164,7 +152,6 @@ assertType('string|void', wp_page_menu($args));
 $args = '';
 assertType('string|void', get_search_form($args));
 assertType('string|void', the_title_attribute($args));
-assertType('string|void', wp_dropdown_languages($args));
 assertType('string|void', wp_get_archives($args));
 assertType('string|void', wp_list_authors($args));
 assertType('string|void', wp_list_bookmarks($args));


### PR DESCRIPTION
Whether `wp_dropdown_languages()` return string or void does not depend on `$args['echo']` but on `$args['id']` and `$args['name']`. See lines [1678-1680](https://github.com/WordPress/WordPress/blob/e25ffd14269ad6461aba63e3119ac5603502bf06/wp-includes/l10n.php#L1678-L1680) and [1780-1784](https://github.com/WordPress/WordPress/blob/e25ffd14269ad6461aba63e3119ac5603502bf06/wp-includes/l10n.php#L1780-L1784) in wp-includes/l10n.php.