### PR TITLE
Add type declarations to properties

### DIFF
--- a/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
+++ b/src/ApplyFiltersDynamicFunctionReturnTypeExtension.php
@@ -16,8 +16,7 @@ use PHPStan\Type\Type;
 
 class ApplyFiltersDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
-    /** @var \SzepeViktor\PHPStan\WordPress\HookDocBlock */
-    protected $hookDocBlock;
+    protected HookDocBlock $hookDocBlock;
 
     public function __construct(HookDocBlock $hookDocBlock)
     {

--- a/src/AssertNotWpErrorTypeSpecifyingExtension.php
+++ b/src/AssertNotWpErrorTypeSpecifyingExtension.php
@@ -19,8 +19,7 @@ use PHPStan\Type\TypeCombinator;
 
 class AssertNotWpErrorTypeSpecifyingExtension implements \PHPStan\Type\MethodTypeSpecifyingExtension, \PHPStan\Analyser\TypeSpecifierAwareExtension
 {
-    /** @var \PHPStan\Analyser\TypeSpecifier */
-    private $typeSpecifier;
+    private TypeSpecifier $typeSpecifier;
 
     public function getClass(): string
     {

--- a/src/AssertWpErrorTypeSpecifyingExtension.php
+++ b/src/AssertWpErrorTypeSpecifyingExtension.php
@@ -18,8 +18,7 @@ use PHPStan\Type\ObjectType;
 
 class AssertWpErrorTypeSpecifyingExtension implements \PHPStan\Type\MethodTypeSpecifyingExtension, \PHPStan\Analyser\TypeSpecifierAwareExtension
 {
-    /** @var \PHPStan\Analyser\TypeSpecifier */
-    private $typeSpecifier;
+    private TypeSpecifier $typeSpecifier;
 
     public function getClass(): string
     {

--- a/src/HookCallbackRule.php
+++ b/src/HookCallbackRule.php
@@ -38,10 +38,9 @@ class HookCallbackRule implements \PHPStan\Rules\Rule
     private const ACCEPTED_ARGS_DEFAULT = 1;
 
     /** @var list<\PHPStan\Rules\IdentifierRuleError> */
-    private $errors;
+    private array $errors;
 
-    /** @var \PHPStan\Analyser\Scope */
-    protected $currentScope;
+    protected Scope $currentScope;
 
     public function getNodeType(): string
     {

--- a/src/HookDocBlock.php
+++ b/src/HookDocBlock.php
@@ -15,8 +15,7 @@ use PHPStan\Type\FileTypeMapper;
 
 class HookDocBlock
 {
-    /** @var \PHPStan\Type\FileTypeMapper */
-    protected $fileTypeMapper;
+    protected FileTypeMapper $fileTypeMapper;
 
     public function __construct(FileTypeMapper $fileTypeMapper)
     {

--- a/src/HookDocsRule.php
+++ b/src/HookDocsRule.php
@@ -31,20 +31,16 @@ class HookDocsRule implements \PHPStan\Rules\Rule
         'do_action',
     ];
 
-    /** @var \SzepeViktor\PHPStan\WordPress\HookDocBlock */
-    protected $hookDocBlock;
+    protected HookDocBlock $hookDocBlock;
 
-    /** @var \PHPStan\Rules\RuleLevelHelper */
-    protected $ruleLevelHelper;
+    protected RuleLevelHelper $ruleLevelHelper;
 
-    /** @var \PhpParser\Node\Expr\FuncCall */
-    protected $currentNode;
+    protected FuncCall $currentNode;
 
-    /** @var \PHPStan\Analyser\Scope */
-    protected $currentScope;
+    protected Scope $currentScope;
 
     /** @var list<\PHPStan\Rules\IdentifierRuleError> */
-    private $errors;
+    private array $errors;
 
     public function __construct(
         FileTypeMapper $fileTypeMapper,

--- a/src/HookDocsVisitor.php
+++ b/src/HookDocsVisitor.php
@@ -8,15 +8,14 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress;
 
+use PhpParser\Comment\Doc;
 use PhpParser\Node;
 
 final class HookDocsVisitor extends \PhpParser\NodeVisitorAbstract
 {
-    /** @var int|null */
-    protected $latestStartLine = null;
+    protected ?int $latestStartLine;
 
-    /** @var \PhpParser\Comment\Doc|null */
-    protected $latestDocComment = null;
+    protected ?Doc $latestDocComment;
 
     // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter
     public function beforeTraverse(array $nodes): ?array

--- a/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
+++ b/src/WpParseUrlFunctionDynamicReturnTypeExtension.php
@@ -40,13 +40,12 @@ use const PHP_URL_USER;
 final class WpParseUrlFunctionDynamicReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
 {
     /** @var array<int, \PHPStan\Type\Type>|null */
-    private $componentTypesPairedConstants = null;
+    private ?array $componentTypesPairedConstants = null;
 
     /** @var array<string, \PHPStan\Type\Type>|null */
-    private $componentTypesPairedStrings = null;
+    private ?array $componentTypesPairedStrings = null;
 
-    /** @var \PHPStan\Type\Type|null */
-    private $allComponentsTogetherType = null;
+    private ?Type $allComponentsTogetherType = null;
 
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {


### PR DESCRIPTION
v2 requires PHP 7.4, so we can now add type declarations to properties.