### PR TITLE
Add support for named arguments in add_filter and add_action

### DIFF
--- a/src/NormalizedArguments.php
+++ b/src/NormalizedArguments.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\ArgumentsNormalizer;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+
+trait NormalizedArguments
+{
+    /**
+     * @return ?array<int, \PhpParser\Node\Arg> $args
+     */
+    private function getNormalizedFunctionArgs(
+        FunctionReflection $functionReflection,
+        FuncCall $functionCall,
+        Scope $scope
+    ): ?array {
+        $parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $functionCall->getArgs(),
+            $functionReflection->getVariants(),
+            $functionReflection->getNamedArgumentsVariants(),
+        );
+
+        $normalizedFunctionCall = ArgumentsNormalizer::reorderFuncArguments(
+            $parametersAcceptor,
+            $functionCall
+        );
+
+        if ($normalizedFunctionCall === null) {
+            return null;
+        }
+
+        return $normalizedFunctionCall->getArgs();
+    }
+}

--- a/tests/HookCallbackRuleTest.php
+++ b/tests/HookCallbackRuleTest.php
@@ -4,17 +4,46 @@ declare(strict_types=1);
 
 namespace SzepeViktor\PHPStan\WordPress\Tests;
 
+use PHPStan\Reflection\ReflectionProvider;
 use SzepeViktor\PHPStan\WordPress\HookCallbackRule;
+
+use const PHP_VERSION_ID;
 
 /**
  * @extends \PHPStan\Testing\RuleTestCase<\SzepeViktor\PHPStan\WordPress\HookCallbackRule>
  */
 class HookCallbackRuleTest extends \PHPStan\Testing\RuleTestCase
 {
+    private const EXPECTED_ERRORS = [
+        ['Filter callback return statement is missing.', 17],
+        ['Filter callback return statement is missing.', 18],
+        ['Callback expects 1 parameter, $accepted_args is set to 0.', 21],
+        ['Callback expects 1 parameter, $accepted_args is set to 2.', 26],
+        ['Callback expects 0-1 parameters, $accepted_args is set to 2.', 31],
+        ['Callback expects 2 parameters, $accepted_args is set to 1.', 36],
+        ['Callback expects 2-4 parameters, $accepted_args is set to 1.', 41],
+        ['Callback expects 2-3 parameters, $accepted_args is set to 4.', 46],
+        ['Action callback returns true but should not return anything.', 51],
+        ['Action callback returns true but should not return anything.', 54],
+        ['Filter callback return statement is missing.', 61],
+        ['Action callback returns false but should not return anything.', 64],
+        ['Action callback returns int but should not return anything.', 67],
+        ['Callback expects at least 1 parameter, $accepted_args is set to 0.', 70],
+        ['Callback expects at least 1 parameter, $accepted_args is set to 0.', 73],
+        ['Callback expects 0-3 parameters, $accepted_args is set to 4.', 78],
+        ['Action callback returns int but should not return anything.', 83],
+        ['Callback expects 0 parameters, $accepted_args is set to 2.', 86],
+        ['Action callback returns false but should not return anything.', 89],
+        ['Action callback returns mixed but should not return anything.', 92],
+        ['Action callback returns null but should not return anything.', 95],
+    ];
+
     protected function getRule(): \PHPStan\Rules\Rule
     {
+        $reflectionProvider = self::getContainer()->getByType(ReflectionProvider::class);
+
         // getRule() method needs to return an instance of the tested rule
-        return new HookCallbackRule();
+        return new HookCallbackRule($reflectionProvider);
     }
 
     public function testRule(): void
@@ -26,96 +55,21 @@ class HookCallbackRuleTest extends \PHPStan\Testing\RuleTestCase
             [
                 __DIR__ . '/data/hook-callback.php',
             ],
+            self::EXPECTED_ERRORS
+        );
+    }
+
+    public function testRuleWithNamedArguments(): void
+    {
+        if (PHP_VERSION_ID < 80000) {
+            $this::markTestSkipped('Named arguments are only supported in PHP 8.0 and later.');
+        }
+
+        $this->analyse(
             [
-                [
-                    'Filter callback return statement is missing.',
-                    17,
-                ],
-                [
-                    'Filter callback return statement is missing.',
-                    20,
-                ],
-                [
-                    'Filter callback return statement is missing.',
-                    23,
-                ],
-                [
-                    'Callback expects 1 parameter, $accepted_args is set to 0.',
-                    26,
-                ],
-                [
-                    'Callback expects 1 parameter, $accepted_args is set to 2.',
-                    31,
-                ],
-                [
-                    'Callback expects 0-1 parameters, $accepted_args is set to 2.',
-                    36,
-                ],
-                [
-                    'Callback expects 2 parameters, $accepted_args is set to 1.',
-                    41,
-                ],
-                [
-                    'Callback expects 2-4 parameters, $accepted_args is set to 1.',
-                    46,
-                ],
-                [
-                    'Callback expects 2-3 parameters, $accepted_args is set to 4.',
-                    51,
-                ],
-                [
-                    'Action callback returns true but should not return anything.',
-                    56,
-                ],
-                [
-                    'Action callback returns true but should not return anything.',
-                    61,
-                ],
-                [
-                    'Filter callback return statement is missing.',
-                    68,
-                ],
-                [
-                    'Action callback returns false but should not return anything.',
-                    71,
-                ],
-                [
-                    'Action callback returns int but should not return anything.',
-                    74,
-                ],
-                [
-                    'Callback expects at least 1 parameter, $accepted_args is set to 0.',
-                    77,
-                ],
-                [
-                    'Callback expects at least 1 parameter, $accepted_args is set to 0.',
-                    80,
-                ],
-                [
-                    'Callback expects 0-3 parameters, $accepted_args is set to 4.',
-                    85,
-                ],
-                [
-                    'Action callback returns int but should not return anything.',
-                    90,
-                ],
-                [
-                    'Callback expects 0 parameters, $accepted_args is set to 2.',
-                    93,
-                ],
-                [
-                    'Action callback returns false but should not return anything.',
-                    96,
-                ],
-                [
-                    'Action callback returns mixed but should not return anything.',
-                    99,
-                ],
-                [
-                    'Action callback returns null but should not return anything.',
-                    102,
-                ],
-            ]
+                __DIR__ . '/data/hook-callback-named-args.php',
+            ],
+            self::EXPECTED_ERRORS
         );
     }
 

--- a/tests/data/hook-callback-named-args.php
+++ b/tests/data/hook-callback-named-args.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function add_filter;
+use function add_action;
+
+// phpcs:disable Squiz.NamingConventions.ValidFunctionName.NotCamelCaps,Squiz.NamingConventions.ValidVariableName.NotCamelCaps,Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
+
+/*
+ * Incorrect usage:
+ */
+
+// Filter callback return statement is missing.
+add_filter(callback: static function () {}, hook_name: 'filter');
+add_filter(callback: static function (array $classes) {}, hook_name: 'filter');
+
+// Callback expects 1 parameter, $accepted_args is set to 0.
+add_filter(callback: static function ($value): int {
+    return 123;
+}, priority: 10, accepted_args: 0, hook_name: 'filter');
+
+// Callback expects 1 parameter, $accepted_args is set to 2.
+add_filter(callback: static function ($value): int {
+    return 123;
+}, accepted_args: 2, priority: 10, hook_name: 'filter');
+
+// Callback expects 0-1 parameters, $accepted_args is set to 2.
+add_filter(callback: static function ($value = null): int {
+    return 123;
+}, priority: 10, accepted_args: 2, hook_name: 'filter');
+
+// Callback expects 2 parameters, $accepted_args is set to 1.
+add_filter(callback: static function ($value1, $value2): int {
+    return 123;
+}, hook_name: 'filter');
+
+// Callback expects 2-4 parameter, $accepted_args is set to 1.
+add_filter(callback: static function ($value1, $value2, $value3 = null, $value4 = null): int {
+    return 123;
+}, hook_name: 'filter');
+
+// Callback expects 2-3 parameter, $accepted_args is set to 4.
+add_filter(callback: static function ($value1, $value2, $value3 = null): int {
+    return 123;
+}, priority: 10, accepted_args: 4, hook_name: 'filter');
+
+// Action callback returns true but should not return anything.
+add_action(callback: static function () {
+    return true;
+}, hook_name: 'action');
+add_action(callback: static function ($value) {
+    if ($value) {
+        return true;
+    }
+}, hook_name: 'action');
+
+// Filter callback return statement is missing.
+add_filter(callback: __NAMESPACE__ . '\\no_return_value_typed', hook_name: 'filter');
+
+// Action callback returns false but should not return anything.
+add_action(callback: '__return_false', hook_name: 'action');
+
+// Action callback returns int but should not return anything.
+add_action(callback: new TestInvokableTyped(), priority: 10, accepted_args: 2, hook_name: 'action');
+
+// Callback expects at least 1 parameter, $accepted_args is set to 0.
+add_filter(callback: __NAMESPACE__ . '\\filter_variadic_typed', priority: 10, accepted_args: 0, hook_name: 'filter');
+
+// Callback expects at least 1 parameter, $accepted_args is set to 0.
+add_filter(callback: static function ($one, ...$two): int {
+    return 123;
+}, priority: 10, accepted_args: 0, hook_name: 'filter');
+
+// Callback expects 0-3 parameters, $accepted_args is set to 4.
+add_filter(callback: static function ($one = null, $two = null, $three = null): int {
+    return 123;
+}, priority: 10, accepted_args: 4, hook_name: 'filter');
+
+// Action callback returns int but should not return anything.
+add_action(callback: __NAMESPACE__ . '\\return_value_typed', hook_name: 'action');
+
+// Callback expects 0 parameters, $accepted_args is set to 2.
+add_filter(callback: '__return_false', priority: 10, accepted_args: 2, hook_name: 'filter');
+
+// Action callback returns false but should not return anything (with incorrect number of accepted args).
+add_action(callback: '__return_false', priority: 10, accepted_args: 2, hook_name: 'action');
+
+// Action callback returns mixed but should not return anything.
+add_action(callback: __NAMESPACE__ . '\\return_value_mixed', hook_name: 'action');
+
+// Action callback returns null but should not return anything.
+add_action(callback: '__return_null', hook_name: 'action');
+
+/*
+ * Incorrect usage that's handled by PHPStan:
+ *
+ * These are here to ensure the rule doesn't trigger unwanted errors.
+ */
+
+// Too few parameters:
+add_filter(hook_name: 'filter');
+add_filter();
+
+// Invalid callback:
+add_filter(callback: 'i_do_not_exist', hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\i_do_not_exist', hook_name: 'filter');
+add_filter(callback: [new TestClassTyped, 'i_do_not_exist'], hook_name: 'filter');
+add_filter(callback: new TestClassTyped, hook_name: 'filter');
+add_filter(callback: $_GET['callback'], hook_name: 'filter');
+
+// Valid callback but with invalid parameters:
+add_filter(callback: static function () {
+    return 123;
+}, priority: false, hook_name: 'filter');
+add_filter(callback: static function () {
+    return 123;
+}, priority: 10, accepted_args: false, hook_name: 'filter');
+
+// Filter callback return statement may be missing.
+add_filter(callback: static function ($class) {
+    if ($class) {
+        return [];
+    }
+}, hook_name: 'filter');
+
+// Incorrect function return type:
+add_filter(callback: static function (array $classes): array {
+    return 123;
+}, hook_name: 'filter');
+
+// Callback function with no declared return type.
+add_action(callback: __NAMESPACE__ . '\\return_value_untyped', hook_name: 'action');
+add_filter(callback: __NAMESPACE__ . '\\no_return_value_untyped', hook_name: 'filter');
+
+/*
+ * Correct usage:
+ */
+
+add_filter(callback: static function () {
+    return 123;
+}, priority: 10, accepted_args: 0, hook_name: 'filter');
+add_filter(callback: static function () {
+    // We're allowing 0 parameters when `$accepted_args` is default value of 1.
+    // This might change in the future to get more strict.
+    return 123;
+}, hook_name: 'filter');
+add_filter(callback: static function ($value) {
+    return 123;
+}, hook_name: 'filter');
+add_filter(callback: static function ($value) {
+    return 123;
+}, priority: 10, accepted_args: 1, hook_name: 'filter');
+add_filter(callback: static function ($value1, $value2) {
+    return 123;
+}, priority: 10, accepted_args: 2, hook_name: 'filter');
+add_filter(callback: static function ($value1, $value2, $value3 = null) {
+    return 123;
+}, priority: 10, accepted_args: 2, hook_name: 'filter');
+add_filter(callback: static function ($value1, $value2, $value3 = null) {
+    return 123;
+}, priority: 10, accepted_args: 3, hook_name: 'filter');
+add_filter(callback: static function ($value = null) {
+    return 123;
+}, hook_name: 'filter');
+add_filter(callback: static function ($value = null) {
+    return 123;
+}, priority: 10, accepted_args: 0, hook_name: 'filter');
+add_filter(callback: static function ($value = null) {
+    return 123;
+}, priority: 10, accepted_args: 1, hook_name: 'filter');
+add_filter(callback: static function ($one = null, $two = null, $three = null) {
+    return 123;
+}, hook_name: 'filter');
+
+// Action callbacks must return void
+add_action(callback: static function () {
+    return;
+}, hook_name: 'action');
+add_action(callback: static function () {}, hook_name: 'action');
+add_action(callback: static function (): void {}, hook_name: 'action');
+add_action(callback: __NAMESPACE__ . '\\no_return_value_typed', hook_name: 'action');
+
+// Filter callback may exit, unfortunately
+add_filter(callback: static function (array $classes) {
+    if ($classes) {
+        exit('Goodbye');
+    }
+
+    return $classes;
+}, hook_name: 'filter');
+
+// Action callback may exit, unfortunately
+add_action(callback: static function ($result) {
+    if (! $result) {
+        exit('Goodbye');
+    }
+}, hook_name: 'action');
+
+// Various callback types
+add_filter(callback: '__return_true', hook_name: 'filter');
+add_filter(callback: '__return_false', hook_name: 'filter');
+add_filter(callback: '__return_zero', hook_name: 'filter');
+add_filter(callback: '__return_null', hook_name: 'filter');
+add_filter(callback: '__return_empty_array', hook_name: 'filter');
+add_filter(callback: '__return_empty_string', hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\return_value_mixed', hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\return_value_mixed_union', hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\return_value_documented', hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\return_value_untyped', hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\return_value_typed', hook_name: 'filter');
+add_filter(callback: new TestInvokableTyped(), priority: 10, accepted_args: 2, hook_name: 'filter');
+add_filter(callback: [new TestClassTyped, 'foo'], hook_name: 'filter');
+
+$test_class = new TestClassTyped();
+
+add_filter(callback: [$test_class, 'foo'], hook_name: 'filter');
+
+// Variadic callbacks
+add_filter(callback: __NAMESPACE__ . '\\filter_variadic_typed', hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\filter_variadic_typed', priority: 10, accepted_args: 1, hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\filter_variadic_typed', priority: 10, accepted_args: 2, hook_name: 'filter');
+add_filter(callback: __NAMESPACE__ . '\\filter_variadic_typed', priority: 10, accepted_args: 999, hook_name: 'filter');
+
+// Mixed named und positional arguments
+add_filter('filter', priority: 2, callback: static function (): int {
+    return 123;
+});
+add_filter('filter', priority: 2, callback: static function ($value): int {
+    return 123;
+});
+add_filter('filter', accepted_args: 2, priority: 2, callback: static function ($one, $two): int {
+    return 123;
+});
+
+// Multiple callbacks with varying signatures
+class MultipleSignatures {
+    const ACTIONS = [
+        'one',
+        'two',
+    ];
+
+    public static function init(): void {
+        foreach (self::ACTIONS as $action) {
+            add_action(callback: [self::class, $action], hook_name: 'action');
+        }
+    }
+
+    public static function one(int $param): void {}
+
+    public static function two(string $param): void {}
+}
+
+/*
+ * Symbol definitions for use in these tests.
+ */
+
+function no_return_value_typed($value): void {}
+
+function return_value_typed(): int {
+    return 123;
+}
+
+function no_return_value_untyped($value) {}
+
+/**
+ * @return mixed
+ */
+function return_value_mixed() {
+    return 123;
+}
+
+/**
+ * Return type documented as a union that includes mixed.
+ *
+ * This is added as a regression test for a bug.
+ *
+ * @return int|mixed
+ */
+function return_value_mixed_union() {
+    return 123;
+}
+
+/**
+ * @return int
+ */
+function return_value_documented() {
+    return 123;
+}
+
+function return_value_untyped() {
+    return 123;
+}
+
+function filter_variadic_typed($one, ...$two): int {
+    return 123;
+}
+
+class TestInvokableTyped {
+    public function __invoke($one, $two): int {
+        return 123;
+    }
+}
+
+class TestClassTyped {
+    public function foo(): int {
+        return 123;
+    }
+}

--- a/tests/data/hook-callback.php
+++ b/tests/data/hook-callback.php
@@ -9,56 +9,49 @@ use function add_action;
 
 // phpcs:disable Squiz.NamingConventions.ValidFunctionName.NotCamelCaps,Squiz.NamingConventions.ValidVariableName.NotCamelCaps,Squiz.NamingConventions.ValidVariableName.MemberNotCamelCaps
 
-/**
+/*
  * Incorrect usage:
  */
 
 // Filter callback return statement is missing.
-add_filter('filter', function() {});
-
-// Filter callback return statement is missing.
-add_filter('filter', function() {});
-
-// Filter callback return statement is missing.
-add_filter('filter', function(array $classes) {});
+add_filter('filter', static function () {});
+add_filter('filter', static function (array $classes) {});
 
 // Callback expects 1 parameter, $accepted_args is set to 0.
-add_filter('filter', function($value) {
+add_filter('filter', static function ($value): int {
     return 123;
 }, 10, 0);
 
 // Callback expects 1 parameter, $accepted_args is set to 2.
-add_filter('filter', function($value) {
+add_filter('filter', static function ($value): int {
     return 123;
 }, 10, 2);
 
 // Callback expects 0-1 parameters, $accepted_args is set to 2.
-add_filter('filter', function($value = null) {
+add_filter('filter', static function ($value = null): int {
     return 123;
 }, 10, 2);
 
 // Callback expects 2 parameters, $accepted_args is set to 1.
-add_filter('filter', function($value1, $value2) {
+add_filter('filter', static function ($value1, $value2): int {
     return 123;
 });
 
 // Callback expects 2-4 parameter, $accepted_args is set to 1.
-add_filter('filter', function($value1, $value2, $value3 = null, $value4 = null) {
+add_filter('filter', static function ($value1, $value2, $value3 = null, $value4 = null): int {
     return 123;
 });
 
 // Callback expects 2-3 parameter, $accepted_args is set to 4.
-add_filter('filter', function($value1, $value2, $value3 = null) {
+add_filter('filter', static function ($value1, $value2, $value3 = null): int {
     return 123;
 }, 10, 4);
 
 // Action callback returns true but should not return anything.
-add_action('action', function() {
+add_action('action', static function () {
     return true;
 });
-
-// Action callback returns true but should not return anything.
-add_action('action', function($value) {
+add_action('action', static function ($value) {
     if ($value) {
         return true;
     }
@@ -77,12 +70,12 @@ add_action('action', new TestInvokableTyped(), 10, 2);
 add_filter('filter', __NAMESPACE__ . '\\filter_variadic_typed', 10, 0);
 
 // Callback expects at least 1 parameter, $accepted_args is set to 0.
-add_filter('filter', function( $one, ...$two ) {
+add_filter('filter', static function ($one, ...$two): int {
     return 123;
 }, 10, 0);
 
 // Callback expects 0-3 parameters, $accepted_args is set to 4.
-add_filter('filter', function($one = null, $two = null, $three = null) {
+add_filter('filter', static function ($one = null, $two = null, $three = null): int {
     return 123;
 }, 10, 4);
 
@@ -101,7 +94,7 @@ add_action('action', __NAMESPACE__ . '\\return_value_mixed');
 // Action callback returns null but should not return anything.
 add_action('action', '__return_null');
 
-/**
+/*
  * Incorrect usage that's handled by PHPStan:
  *
  * These are here to ensure the rule doesn't trigger unwanted errors.
@@ -111,38 +104,30 @@ add_action('action', '__return_null');
 add_filter('filter');
 add_filter();
 
-// Invalid callback:
+// Invalid callback
 add_filter('filter', 'i_do_not_exist');
-
-// Invalid callback:
 add_filter('filter', __NAMESPACE__ . '\\i_do_not_exist');
-
-// Invalid callback:
 add_filter('filter', [new TestClassTyped, 'i_do_not_exist']);
-
-// Invalid callback:
 add_filter('filter', new TestClassTyped);
-
-// Unknown callback:
 add_filter('filter', $_GET['callback']);
 
 // Valid callback but with invalid parameters:
-add_filter('filter', function() {
+add_filter('filter', static function (): int {
     return 123;
 }, false);
-add_filter('filter', function() {
+add_filter('filter', static function (): int {
     return 123;
 }, 10, false);
 
 // Filter callback return statement may be missing.
-add_filter('filter', function($class) {
+add_filter('filter', static function ($class) {
     if ($class) {
         return [];
     }
 });
 
 // Incorrect function return type:
-add_filter('filter', function(array $classes): array {
+add_filter('filter', static function (array $classes): array {
     return 123;
 });
 
@@ -150,58 +135,56 @@ add_filter('filter', function(array $classes): array {
 add_action('action', __NAMESPACE__ . '\\return_value_untyped');
 add_filter('filter', __NAMESPACE__ . '\\no_return_value_untyped');
 
-/**
+/*
  * Correct usage:
  */
 
-add_filter('filter', function() {
+add_filter('filter', static function (): int {
     return 123;
 }, 10, 0);
-add_filter('filter', function() {
+add_filter('filter', static function (): int {
     // We're allowing 0 parameters when `$accepted_args` is default value of 1.
     // This might change in the future to get more strict.
     return 123;
 });
-add_filter('filter', function($value) {
+add_filter('filter', static function ($value): int {
     return 123;
 });
-add_filter('filter', function($value) {
+add_filter('filter', static function ($value): int {
     return 123;
 }, 10, 1);
-add_filter('filter', function($value1, $value2) {
+add_filter('filter', static function ($value1, $value2): int {
     return 123;
 }, 10, 2);
-add_filter('filter', function($value1, $value2, $value3 = null) {
+add_filter('filter', static function ($value1, $value2, $value3 = null): int {
     return 123;
 }, 10, 2);
-add_filter('filter', function($value1, $value2, $value3 = null) {
+add_filter('filter', static function ($value1, $value2, $value3 = null): int {
     return 123;
 }, 10, 3);
-add_filter('filter', function($value = null) {
+add_filter('filter', static function ($value = null): int {
     return 123;
 });
-add_filter('filter', function($value = null) {
+add_filter('filter', static function ($value = null): int {
     return 123;
 }, 10, 0);
-add_filter('filter', function($value = null) {
+add_filter('filter', static function ($value = null): int {
     return 123;
 }, 10, 1);
-add_filter('filter', function($one = null, $two = null, $three = null) {
+add_filter('filter', static function ($one = null, $two = null, $three = null): int {
     return 123;
 });
 
 // Action callbacks must return void
-add_action('action', function() {
+add_action('action', static function (): void {
     return;
 });
-add_action('action', function() {
-});
-add_action('action', function(): void {
-});
+add_action('action', static function (): void {});
+add_action('action', static function (): void {});
 add_action('action', __NAMESPACE__ . '\\no_return_value_typed');
 
 // Filter callback may exit, unfortunately
-add_filter('filter', function(array $classes) {
+add_filter('filter', static function (array $classes) {
     if ($classes) {
         exit('Goodbye');
     }
@@ -210,7 +193,7 @@ add_filter('filter', function(array $classes) {
 });
 
 // Action callback may exit, unfortunately
-add_action('action', function($result) {
+add_action('action', static function ($result): void {
     if (! $result) {
         exit('Goodbye');
     }
@@ -243,33 +226,33 @@ add_filter('filter', __NAMESPACE__ . '\\filter_variadic_typed', 10, 999);
 
 // Multiple callbacks with varying signatures
 class MultipleSignatures {
-    const ACTIONS = array(
+    const ACTIONS = [
         'one',
         'two',
-    );
+    ];
 
     public static function init(): void {
-        foreach ( self::ACTIONS as $action ) {
-            add_action( 'action', array( self::class, $action ) );
+        foreach (self::ACTIONS as $action) {
+            add_action('action', [self::class, $action]);
         }
     }
 
-    public static function one( int $param ): void {}
+    public static function one(int $param): void {}
 
-    public static function two( string $param ): void {}
+    public static function two(string $param): void {}
 }
 
-/**
+/*
  * Symbol definitions for use in these tests.
  */
 
-function no_return_value_typed( $value ) : void {}
+function no_return_value_typed($value): void {}
 
-function return_value_typed() : int {
+function return_value_typed(): int {
     return 123;
 }
 
-function no_return_value_untyped( $value ) {}
+function no_return_value_untyped($value) {}
 
 /**
  * @return mixed
@@ -300,18 +283,18 @@ function return_value_untyped() {
     return 123;
 }
 
-function filter_variadic_typed( $one, ...$two ) : int {
+function filter_variadic_typed($one, ...$two): int {
     return 123;
 }
 
 class TestInvokableTyped {
-    public function __invoke($one, $two) : int {
+    public function __invoke($one, $two): int {
         return 123;
     }
 }
 
 class TestClassTyped {
-    public function foo() : int {
+    public function foo(): int {
         return 123;
     }
 }


### PR DESCRIPTION
Closes #194

> [!NOTE]  
> "WordPress does not support named parameters."
See [Core Handbook](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/)

WordPress does not support named arguments, which means that some issues are not yet resolved (see ticket [PHP 8.0: improvements to allow for named parameters](https://core.trac.wordpress.org/ticket/59649) for details). However, `add_filter` and `add_action` are unaffected by these issues.