### PR TITLE
Remove testing wp_parse_url without argument

### DIFF
--- a/tests/data/wp_parse_url.php
+++ b/tests/data/wp_parse_url.php
@@ -17,12 +17,6 @@ $integer = doFoo();
 /** @var string $string */
 $string = doFoo();
 
-/**
- * wp_parse_url()
- */
-$value = wp_parse_url();
-assertType('mixed', $value);
-
 $value = wp_parse_url('http://abc.def');
 assertType("array{scheme: 'http', host: 'abc.def'}", $value);
 


### PR DESCRIPTION
`$url` is required (see [function reference](https://developer.wordpress.org/reference/functions/wp_parse_url/)).