### PR TITLE
Add rule to suggest replacing WP constants with function calls

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -32,6 +32,7 @@ services:
 rules:
     - SzepeViktor\PHPStan\WordPress\HookCallbackRule
     - SzepeViktor\PHPStan\WordPress\HookDocsRule
+    - SzepeViktor\PHPStan\WordPress\WpConstantFetchRule
 parameters:
     bootstrapFiles:
         - ../../php-stubs/wordpress-stubs/wordpress-stubs.php

--- a/src/WpConstantFetchRule.php
+++ b/src/WpConstantFetchRule.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Custom rule to discourage using WordPress constants fetchable via functions.
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\RuleErrorBuilder;
+
+use function array_key_exists;
+use function sprintf;
+
+/**
+ * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Expr\ConstFetch>
+ */
+final class WpConstantFetchRule implements \PHPStan\Rules\Rule
+{
+    protected const REPLACEMENTS = [
+        'BACKGROUND_COLOR' => "get_theme_support('custom-background')",
+        'BACKGROUND_IMAGE' => "get_theme_support('custom-background')",
+        'DISALLOW_FILE_MODS' => 'wp_is_file_mod_allowed()',
+        'DOING_AJAX' => 'wp_doing_ajax()',
+        'DOING_CRON' => 'wp_doing_cron()',
+        'FORCE_SSL_ADMIN' => 'force_ssl_admin()',
+        'FORCE_SSL_LOGIN' => 'force_ssl_admin()',
+        'FS_METHOD' => 'get_filesystem_method()',
+        'HEADER_IMAGE' => "get_theme_support('custom-header\)",
+        'HEADER_IMAGE_WIDTH' => "get_theme_support('custom-header')",
+        'HEADER_IMAGE_HEIGHT' => "get_theme_support('custom-header')",
+        'HEADER_TEXTCOLOR' => "get_theme_support('custom-header')",
+        'MULTISITE' => 'is_multisite()',
+        'NO_HEADER_TEXT' => "get_theme_support('custom-header')",
+        'STYLESHEETPATH' => 'get_stylesheet_directory()',
+        'SUBDOMAIN_INSTALL' => 'is_subdomain_install()',
+        'TEMPLATEPATH' => 'get_template_directory()',
+        'UPLOADS' => 'wp_get_upload_dir() or wp_upload_dir(null, false)',
+        'VHOST' => 'is_subdomain_install()',
+        'WP_ADMIN' => 'is_admin()',
+        'WP_BLOG_ADMIN' => 'is_blog_admin()',
+        'WP_CONTENT_URL' => 'content_url()',
+        'WP_DEVELOPMENT_MODE' => 'wp_get_development_mode()',
+        'WP_HOME' => 'home_url() or get_home_url()',
+        'WP_INSTALLING' => 'wp_installing()',
+        'WP_NETWORK_ADMIN' => 'is_network_admin()',
+        'WP_PLUGIN_URL' => "plugins_url() or plugin_dir_url('')",
+        'WP_POST_REVISIONS' => 'wp_revisions_to_keep()',
+        'WP_SITEURL' => 'site_url() or get_site_url()',
+        'WP_USER_ADMIN' => 'is_user_admin()',
+        'WP_USE_THEMES' => 'wp_using_themes()',
+        'WPMU_PLUGIN_URL' => 'plugins_url()',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\ConstFetch::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (! $this->isDiscouragedConstant($node->name)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Found usage of constant %s. Use %s instead.',
+                    (string)$node->name,
+                    $this->getReplacement($node->name)
+                )
+            )
+                ->identifier('phpstanWP.wpConstant.fetch')
+                ->build(),
+        ];
+    }
+
+    private function isDiscouragedConstant(Node\Name $constantName): bool
+    {
+        return array_key_exists((string)$constantName, self::REPLACEMENTS);
+    }
+
+    private function getReplacement(Node\Name $constantName): string
+    {
+        return self::REPLACEMENTS[(string)$constantName];
+    }
+}

--- a/tests/WpConstantFetchRuleTest.php
+++ b/tests/WpConstantFetchRuleTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use PHPStan\Rules\Rule;
+use SzepeViktor\PHPStan\WordPress\WpConstantFetchRule;
+
+/**
+ * @extends \PHPStan\Testing\RuleTestCase<\SzepeViktor\PHPStan\WordPress\WpConstantFetchRule>
+ */
+class WpConstantFetchRuleTest extends \PHPStan\Testing\RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new WpConstantFetchRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/data/wp-constants.php',
+                __DIR__ . '/data/internal-error.php',
+            ],
+            [
+                ["Found usage of constant BACKGROUND_COLOR. Use get_theme_support('custom-background') instead.", 9],
+                ["Found usage of constant BACKGROUND_IMAGE. Use get_theme_support('custom-background') instead.", 10],
+                ['Found usage of constant DISALLOW_FILE_MODS. Use wp_is_file_mod_allowed() instead.', 11],
+                ['Found usage of constant DOING_AJAX. Use wp_doing_ajax() instead.', 12],
+                ['Found usage of constant DOING_CRON. Use wp_doing_cron() instead.', 13],
+                ['Found usage of constant FORCE_SSL_ADMIN. Use force_ssl_admin() instead.', 14],
+                ['Found usage of constant FORCE_SSL_LOGIN. Use force_ssl_admin() instead.', 15],
+                ['Found usage of constant FS_METHOD. Use get_filesystem_method() instead.', 16],
+                ['Found usage of constant MULTISITE. Use is_multisite() instead.', 17],
+                ['Found usage of constant STYLESHEETPATH. Use get_stylesheet_directory() instead.', 18],
+                ['Found usage of constant SUBDOMAIN_INSTALL. Use is_subdomain_install() instead.', 19],
+                ['Found usage of constant TEMPLATEPATH. Use get_template_directory() instead.', 20],
+                ['Found usage of constant UPLOADS. Use wp_get_upload_dir() or wp_upload_dir(null, false) instead.', 21],
+                ['Found usage of constant VHOST. Use is_subdomain_install() instead.', 22],
+                ['Found usage of constant WP_ADMIN. Use is_admin() instead.', 23],
+                ['Found usage of constant WP_BLOG_ADMIN. Use is_blog_admin() instead.', 24],
+                ['Found usage of constant WP_CONTENT_URL. Use content_url() instead.', 25],
+                ['Found usage of constant WP_DEVELOPMENT_MODE. Use wp_get_development_mode() instead.', 26],
+                ['Found usage of constant WP_HOME. Use home_url() or get_home_url() instead.', 27],
+                ['Found usage of constant WP_INSTALLING. Use wp_installing() instead.', 28],
+                ['Found usage of constant WP_NETWORK_ADMIN. Use is_network_admin() instead.', 29],
+                ["Found usage of constant WP_PLUGIN_URL. Use plugins_url() or plugin_dir_url('') instead.", 30],
+                ['Found usage of constant WP_POST_REVISIONS. Use wp_revisions_to_keep() instead.', 31],
+                ['Found usage of constant WP_SITEURL. Use site_url() or get_site_url() instead.', 32],
+                ['Found usage of constant WP_USER_ADMIN. Use is_user_admin() instead.', 33],
+                ['Found usage of constant WP_USE_THEMES. Use wp_using_themes() instead.', 34],
+                ['Found usage of constant WPMU_PLUGIN_URL. Use plugins_url() instead.', 35],
+            ]
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [dirname(__DIR__) . '/vendor/szepeviktor/phpstan-wordpress/extension.neon'];
+    }
+}

--- a/tests/data/wp-constants.php
+++ b/tests/data/wp-constants.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+// WpConstantFetchRule
+$ruleDoesNotApply = MB_IN_BYTES;
+$ruleApplies = BACKGROUND_COLOR;
+$ruleApplies = BACKGROUND_IMAGE;
+$ruleApplies = DISALLOW_FILE_MODS;
+$ruleApplies = DOING_AJAX;
+$ruleApplies = DOING_CRON;
+$ruleApplies = FORCE_SSL_ADMIN;
+$ruleApplies = FORCE_SSL_LOGIN;
+$ruleApplies = FS_METHOD;
+$ruleApplies = MULTISITE;
+$ruleApplies = STYLESHEETPATH;
+$ruleApplies = SUBDOMAIN_INSTALL;
+$ruleApplies = TEMPLATEPATH;
+$ruleApplies = UPLOADS;
+$ruleApplies = VHOST;
+$ruleApplies = WP_ADMIN;
+$ruleApplies = WP_BLOG_ADMIN;
+$ruleApplies = WP_CONTENT_URL;
+$ruleApplies = WP_DEVELOPMENT_MODE;
+$ruleApplies = WP_HOME;
+$ruleApplies = WP_INSTALLING;
+$ruleApplies = WP_NETWORK_ADMIN;
+$ruleApplies = WP_PLUGIN_URL;
+$ruleApplies = WP_POST_REVISIONS;
+$ruleApplies = WP_SITEURL;
+$ruleApplies = WP_USER_ADMIN;
+$ruleApplies = WP_USE_THEMES;
+$ruleApplies = WPMU_PLUGIN_URL;


### PR DESCRIPTION
Adds a rule that checks for the use of certain WordPress constants. If such constants are found, an error will be triggered, suggesting replacing the constant with a function call.

I also suggest removing the following lines:  
https://github.com/szepeviktor/phpstan-wordpress/blob/6686dc2412cdf544556d428e67aa8f0b645164ca/bootstrap.php#L69C1-L72C49  
as `STYLESHEETPATH` and `TEMPLATEPATH` were deprecated in WordPress v6.4.0. Additionally, these constants may need to be added to `dynamicConstantNames` to avoid always-true and always-false errors.