### PR TITLE
Update examples

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -2,10 +2,10 @@
     "name": "company/wordpress-project",
     "description": "WordPress project.",
     "require": {
-        "php": "^7.1"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
-        "szepeviktor/phpstan-wordpress": "^0.6.0"
+        "szepeviktor/phpstan-wordpress": "^2.0"
     },
     "config": {
         "optimize-autoloader": true

--- a/examples/fix-callable.php
+++ b/examples/fix-callable.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Tell PHPStan it is callable type.
- */
-
-/** @var callable $callable */
-$callable = [ $instance, $method ];
-call_user_func_array( $callable, $args );
-add_action( 'hook', $callable );

--- a/examples/fix-parse_url.php
+++ b/examples/fix-parse_url.php
@@ -1,7 +1,0 @@
-<?php
-/**
- * Example of parse_url() usage.
- */
-
-/** @var array<string, string> */
-$parsed_url = parse_url( urldecode( $url ) );

--- a/examples/fix-wpdb.php
+++ b/examples/fix-wpdb.php
@@ -1,7 +1,0 @@
-<?php
-/**
- * Allow usage of $wpdb.
- */
-
-global $wpdb;
-$wpdb = new \wpdb( '', '', '', '' );

--- a/examples/impure-have-functions.stub
+++ b/examples/impure-have-functions.stub
@@ -1,29 +1,6 @@
 <?php
 
 /**
- * Whether current WordPress query has results to loop over.
- *
- * @return bool
- * @phpstan-impure
- */
-function have_posts()
-{
-}
-
-class WP_Query
-{
-    /**
-     * Determines whether there are more posts available in the loop.
-     *
-     * @return bool True if posts are available, false if end of loop.
-     * @phpstan-impure
-     */
-    public function have_posts()
-    {
-    }
-}
-
-/**
  * ACF have_rows()
  *
  * @param   string $selector The field name or field key.

--- a/examples/phpstan-full.neon
+++ b/examples/phpstan-full.neon
@@ -26,15 +26,6 @@ parameters:
     ignoreErrors:
         # Uses func_get_args()
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
-        # Fixed in WordPress 5.3
-        #- '#^Function do_action(_ref_array)? invoked with [3456] parameters, 1-2 required\.$#'
-        #- '#^Function current_user_can invoked with 2 parameters, 1 required\.$#'
-        #- '#^Function add_query_arg invoked with [123] parameters?, 0 required\.$#'
-        #- '#^Function wp_sprintf invoked with [23456] parameters, 1 required\.$#'
-        #- '#^Function add_post_type_support invoked with [345] parameters, 2 required\.$#'
-        #- '#^Function ((get|add)_theme_support|current_theme_supports) invoked with [2345] parameters, 1 required\.$#'
-        # Fixed in WordPress 5.2 - https://core.trac.wordpress.org/ticket/43304
-        #- '/^Parameter #2 \$deprecated of function load_plugin_textdomain expects string, false given\.$/'
         # WP-CLI accepts a class name as callable
         - '/^Parameter #2 \$callable of static method WP_CLI::add_command\(\) expects callable\(\): mixed, \S+ given\.$/'
         # Please consider commenting ignores: issue URL or reason for ignoring


### PR DESCRIPTION
Removes the following files as the examples are outdated:  
- `fix-callable.php`: PHPStan recognises `$callable = [ $instance, $method ];` as a callable  
- `fix-parse-url.php`: PHPStan knows the [return type of `parse_url`](https://github.com/phpstan/phpstan-src/blob/2.1.x/src/Type/Php/ParseUrlFunctionDynamicReturnTypeExtension.php)  
- `fix-wpdb.php`: the stubs file adds `global $wpdb;`  

Updates the following files:  
- `phpstan-full.neon`: WordPress versions lower than 6.6 are not supported  
- `impure-have-functions.stub`: the stubs file informs PHPStan that `have_posts` and `WP_Query::have_posts` are impure  
- `composer.json`: bump the required PHP version to versions supported by the current version of `phpstan-wordpress`; bump the version of `phpstan-wordpress` to prevent incorrect requirements via copy and paste