### PR TITLE
Remove `WP_CLI::error` from earlyTerminatingMethodCalls config

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -55,5 +55,4 @@ parameters:
         WP_Ajax_Response:
             - send
         WP_CLI:
-            - error
             - halt


### PR DESCRIPTION
`WP_CLI::error` supports an `$exit` parameter to disable terminating.

Fixes: #213