### PR TITLE
Remove `SAVEQUERIES` from the `dynamicConstantNames` list

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -44,7 +44,6 @@ parameters:
         - EMPTY_TRASH_DAYS
         - WP_CLI
         - COOKIE_DOMAIN
-        - SAVEQUERIES
         - SCRIPT_DEBUG
     earlyTerminatingFunctionCalls:
         - wp_send_json


### PR DESCRIPTION
This PR removes the `SAVEQUERIES` constant from the `dynamicConstantNames` list in `extension.neon`, as it is not defined by WordPress (see this [GitHub search](https://github.com/search?q=repo%3AWordPress%2Fwordpress+SAVEQUERIES&type=code)).

Including `SAVEQUERIES` in the `dynamicConstantNames` list prevents PHPStan from reporting the following code:
```php
if (SAVEQUERIES) {
    // do something
}
```
If `SAVEQUERIES` is not defined, this will trigger a fatal error in PHP 8+.