### PR TITLE
Remove `WP_CLI` from the dynamicConstantNames list

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -42,7 +42,6 @@ parameters:
         - WP_DEBUG_LOG
         - WP_DEBUG_DISPLAY
         - EMPTY_TRASH_DAYS
-        - WP_CLI
         - COOKIE_DOMAIN
         - SAVEQUERIES
         - SCRIPT_DEBUG


### PR DESCRIPTION
This PR removes the `WP_CLI` constant from the `dynamicConstantNames` list in `extension.neon`, as it is not defined by WordPress (see this [GitHub search](https://github.com/search?q=repo%3AWordPress%2Fwordpress+WP_CLI&type=code)), but rather by WP-CLI.

Including `WP_CLI` in the `dynamicConstantNames` list prevents PHPStan from reporting the following code:
```php
if (WP_CLI) {
    // do something
}
```
If `WP_CLI` is not defined, this will trigger a fatal error in PHP 8+.

Those using WP-CLI can easily add the `WP_CLI` constant to their own configuration. Therefore, this package should not prevent PHPStan from reporting potential fatal errors for some users.

Related #287