### PR TITLE
Remove `WP_CLI::halt` from earlyTerminatingMethodCalls

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -52,5 +52,3 @@ parameters:
             - output
         WP_Ajax_Response:
             - send
-        WP_CLI:
-            - halt


### PR DESCRIPTION
The return type of `WP_CLI::halt` is now correctly documented in WP-CLI itself and in its stubs (see [method declaration](https://github.com/wp-cli/wp-cli/blob/dfae1c11476ee5ba33aff4adf0fccbccf2d50c73/php/class-wp-cli.php#L937-L953) and [method stub](https://github.com/php-stubs/wp-cli-stubs/blob/af16401e299a3fd2229bd0fa9a037638a4174a9d/wp-cli-stubs.php#L4590-L4603)).

Related #284