### PR TITLE
Remove `STYLESHEETPATH` and `TEMPLATEPATH` from bootstrap.php

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -65,8 +65,4 @@ define('EP_ALL_ARCHIVES', EP_DATE | EP_YEAR | EP_MONTH | EP_DAY | EP_CATEGORIES 
 define('EP_ALL', EP_PERMALINK | EP_ATTACHMENT | EP_ROOT | EP_COMMENTS | EP_SEARCH | EP_PAGES | EP_ALL_ARCHIVES);
 
 // Templating-related WordPress constants.
-// phpcs:ignore WordPress.WP.DiscouragedConstants.STYLESHEETPATHDeclarationFound
-define('STYLESHEETPATH', '/app/wp-content/themes/child/');
-// phpcs:ignore WordPress.WP.DiscouragedConstants.TEMPLATEPATHDeclarationFound
-define('TEMPLATEPATH', '/app/wp-content/themes/parent/');
 define('WP_DEFAULT_THEME', 'twentytwentythree');


### PR DESCRIPTION
`STYLESHEETPATH` and `TEMPLATEPATH` have been deprecated in WP 6.4.0 and are handled via the `WpConstantFetchRule` rule.