### PR TITLE
Add return type extension for stripslashes_from_strings_only()

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -2,6 +2,10 @@ services:
     -
         class: SzepeViktor\PHPStan\WordPress\HookDocBlock
     -
+        class: SzepeViktor\PHPStan\WordPress\ApplyFiltersDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\EscSqlDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
@@ -10,7 +14,7 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
-        class: SzepeViktor\PHPStan\WordPress\ApplyFiltersDynamicFunctionReturnTypeExtension
+        class: SzepeViktor\PHPStan\WordPress\StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -

--- a/src/StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension.php
+++ b/src/StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeTraverser;
+
+class StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'stripslashes_from_strings_only';
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/functions/stripslashes_from_strings_only/
+     */
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+    {
+        if (count($functionCall->getArgs()) === 0) {
+            return null;
+        }
+
+        $argType = $scope->getType($functionCall->getArgs()[0]->value);
+
+        return TypeTraverser::map(
+            $argType,
+            static function (Type $type): Type {
+                if ($type instanceof ConstantStringType) {
+                    return new ConstantStringType(stripslashes($type->getValue()));
+                }
+                return $type;
+            }
+        );
+    }
+}

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -16,6 +16,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from self::gatherAssertTypes(__DIR__ . '/data/ApplyFiltersTestClass.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/esc_sql.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/stripslashes-from-strings-only.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp_parse_url.php');
     }
 

--- a/tests/data/stripslashes-from-strings-only.php
+++ b/tests/data/stripslashes-from-strings-only.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function stripslashes_from_strings_only;
+use function PHPStan\Testing\assertType;
+
+assertType("''", stripslashes_from_strings_only(''));
+assertType("'foo'", stripslashes_from_strings_only('foo'));
+assertType("'foo\'s bar'", stripslashes_from_strings_only('foo\'s bar'));
+/** @var lowercase-string $value */
+assertType('lowercase-string', stripslashes_from_strings_only($value));
+
+assertType('array{}', stripslashes_from_strings_only([]));
+assertType("array{'foo'}", stripslashes_from_strings_only(['foo']));
+assertType("array{'foo\\'s bar'}", stripslashes_from_strings_only(['foo\'s bar']));


### PR DESCRIPTION
See https://github.com/php-stubs/wordpress-stubs/issues/333