### PR TITLE
Fix StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -23,6 +23,11 @@
         <exclude-pattern>tests/DynamicConstantTypeTest.php</exclude-pattern>
     </rule>
 
+    <!-- TypeTraverser uses callable $traverse -->
+    <rule ref="NeutronStandard.Functions.VariableFunctions.VariableFunction">
+        <exclude-pattern>src/StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension.php</exclude-pattern>
+    </rule>
+
     <!-- Allow string concatenation in tests -->
     <rule ref="PSR12NeutronRuleset.Strings.ConcatenationUsage.NotAllowed">
         <exclude-pattern>tests/*</exclude-pattern>

--- a/src/StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension.php
+++ b/src/StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SzepeViktor\PHPStan\WordPress;
 
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\UnionType;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\Constant\ConstantStringType;
@@ -31,10 +32,15 @@ class StripslashesFromStringsOnlyDynamicFunctionReturnTypeExtension implements \
 
         return TypeTraverser::map(
             $argType,
-            static function (Type $type): Type {
+            static function (Type $type, callable $traverse): Type {
+                if ($type instanceof UnionType) {
+                    return $traverse($type);
+                }
+
                 if ($type instanceof ConstantStringType) {
                     return new ConstantStringType(stripslashes($type->getValue()));
                 }
+
                 return $type;
             }
         );

--- a/tests/data/stripslashes-from-strings-only.php
+++ b/tests/data/stripslashes-from-strings-only.php
@@ -16,3 +16,5 @@ assertType('lowercase-string', stripslashes_from_strings_only($value));
 assertType('array{}', stripslashes_from_strings_only([]));
 assertType("array{'foo'}", stripslashes_from_strings_only(['foo']));
 assertType("array{'foo\\'s bar'}", stripslashes_from_strings_only(['foo\'s bar']));
+
+assertType("'foo\'s bar'|array{'foo\\'s bar'}", stripslashes_from_strings_only(rand(0, 1) === 1 ? ['foo\'s bar'] : 'foo\'s bar'));


### PR DESCRIPTION
In #294, I missed to add unions.