### PR TITLE
Add return type extension for normalize_whitespace

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -10,6 +10,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: SzepeViktor\PHPStan\WordPress\NormalizeWhitespaceDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\ShortcodeAttsDynamicFunctionReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/NormalizeWhitespaceDynamicFunctionReturnTypeExtension.php
+++ b/src/NormalizeWhitespaceDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Accessory\AccessoryNonEmptyStringType;
+use PHPStan\Type\Accessory\AccessoryType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\GeneralizePrecision;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\TypeUtils;
+use PHPStan\Type\UnionType;
+
+final class NormalizeWhitespaceDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'normalize_whitespace';
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/functions/normalize_whitespace/
+     *
+     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
+     */
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+    {
+        if (count($functionCall->getArgs()) < 1) {
+            return null;
+        }
+
+        $argType = $scope->getType($functionCall->getArgs()[0]->value);
+        if (! $scope->isDeclareStrictTypes()) {
+            $argType = $argType->toString();
+        }
+
+        if (! $argType->isString()->yes()) {
+            return null;
+        }
+
+        $argTypes = $argType instanceof UnionType ? $argType->getTypes() : [$argType];
+
+        $types = [];
+        foreach ($argTypes as $type) {
+            if ($type->isConstantValue()->yes()) {
+                $types[] = $this->getTypeFromConstantString($type->getConstantStrings()[0]);
+                continue;
+            }
+
+            if ($type->isNonFalsyString()->yes()) {
+                $types[] = $this->getTypeFromNonFalsyString($type);
+                continue;
+            }
+
+            if ($type->isNonEmptyString()->yes()) {
+                $types[] = $this->getTypeFromNonEmptyString($type);
+                continue;
+            }
+
+            $types[] = $type;
+        }
+
+        return TypeCombinator::union(...$types);
+    }
+
+    private function getTypeFromConstantString(ConstantStringType $type): Type
+    {
+        $typeValue = $type->getValue();
+        $type = new ConstantStringType(trim($typeValue));
+
+        if ($type->isNonEmptyString()->no() || $type->isNonFalsyString()->no()) {
+            return $type;
+        }
+
+        return $type->generalize(GeneralizePrecision::moreSpecific());
+    }
+
+    private function getTypeFromNonFalsyString(Type $type): Type
+    {
+        $types = array_merge(
+            [new StringType(), new AccessoryNonEmptyStringType()],
+            array_filter(
+                TypeUtils::getAccessoryTypes($type),
+                static function (AccessoryType $accessoryType): bool {
+                    return ! $accessoryType->isNonFalsyString()->yes();
+                }
+            )
+        );
+
+        return TypeCombinator::intersect(...$types);
+    }
+
+    private function getTypeFromNonEmptyString(Type $type): Type
+    {
+        $types = array_merge(
+            [new StringType()],
+            array_filter(
+                TypeUtils::getAccessoryTypes($type),
+                static function (AccessoryType $accessoryType): bool {
+                    return ! $accessoryType->isNonEmptyString()->yes();
+                }
+            )
+        );
+
+        return TypeCombinator::intersect(...$types);
+    }
+}

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -15,6 +15,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from self::gatherAssertTypes(__DIR__ . '/data/apply_filters.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/ApplyFiltersTestClass.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/esc_sql.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/normalize-whitespace.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/stripslashes-from-strings-only.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp_parse_url.php');

--- a/tests/data/normalize-whitespace.php
+++ b/tests/data/normalize-whitespace.php
@@ -12,7 +12,6 @@ assertType("''", normalize_whitespace(' '));
 assertType("'0'", normalize_whitespace(' 0 '));
 
 assertType('literal-string&lowercase-string&non-falsy-string', normalize_whitespace(' foo '));
-assertType('literal-string&non-falsy-string&uppercase-string', normalize_whitespace(' FOO '));
 assertType('literal-string&non-falsy-string', normalize_whitespace(' Foo '));
 
 /** @var non-empty-string $nonEmptyString */

--- a/tests/data/normalize-whitespace.php
+++ b/tests/data/normalize-whitespace.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function normalize_whitespace;
+use function PHPStan\Testing\assertType;
+
+assertType("''", normalize_whitespace(''));
+assertType("''", normalize_whitespace(' '));
+assertType("'0'", normalize_whitespace(' 0 '));
+
+assertType('literal-string&lowercase-string&non-falsy-string', normalize_whitespace(' foo '));
+assertType('literal-string&non-falsy-string&uppercase-string', normalize_whitespace(' FOO '));
+assertType('literal-string&non-falsy-string', normalize_whitespace(' Foo '));
+
+/** @var non-empty-string $nonEmptyString */
+assertType('string', normalize_whitespace($nonEmptyString));
+
+/** @var non-falsy-string $nonFalsyString */
+assertType('non-empty-string', normalize_whitespace($nonFalsyString));
+
+/** @var lowercase-string&non-falsy-string $nonFalsyLowercaseString */
+assertType('lowercase-string&non-empty-string', normalize_whitespace($nonFalsyLowercaseString));
+
+/** @var literal-string $literalString */
+assertType('literal-string', normalize_whitespace($literalString));


### PR DESCRIPTION
Adds return type extension for [`normalize_whitespace()`](https://developer.wordpress.org/reference/functions/normalize_whitespace/).

For constant strings:
- trims strings
- keeps empty and falsy strings
- generalises all other constant strings

For non-constant strings:
- converts `non-falsy-string` to `non-empty-string` (`' 0'` is no longer non-falsy after `trim()`)
- converts `non-empty-string` to `string` (`' '` is no longer non-empty after `trim()`)
- preserves all other `AccessoryType`s