### PR TITLE
Gather assert types conditional on installed PHPStan version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,11 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "php-stubs/wordpress-stubs": "^6.6.2",
-        "phpstan/phpstan": "^2.1.18"
+        "phpstan/phpstan": "^2.0"
     },
     "require-dev": {
         "composer/composer": "^2.1.14",
+        "composer/semver": "^3.4",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.1",
         "phpstan/phpstan-strict-rules": "^2.0",
@@ -42,7 +43,8 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        },
+        "sort-packages": true
     },
     "extra": {
         "phpstan": {

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -11,16 +11,21 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
      */
     public function dataFileAsserts(): iterable
     {
-        // Path to a file with actual asserts of expected types:
         yield from self::gatherAssertTypes(__DIR__ . '/data/apply-filters.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/ApplyFiltersTestClass.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/esc-sql.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/normalize-whitespace.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/shortcode-atts.php');
-        yield from self::gatherAssertTypes(__DIR__ . '/data/slashit-functions.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/stripslashes-from-strings-only.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp-parse-url.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp-slash.php');
+
+        $phpstanVersion = self::getContainer()->getByType(InstalledPhpStanVersion::class);
+
+        if ($phpstanVersion->satisfies('^2.1.18')) {
+            // Improved rtrim handling in PHPStan 2.1.18 gives different results
+            yield from self::gatherAssertTypes(__DIR__ . '/data/slashit-functions.php');
+        }
     }
 
     /**
@@ -34,6 +39,9 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
 
     public static function getAdditionalConfigFiles(): array
     {
-        return [dirname(__DIR__) . '/vendor/szepeviktor/phpstan-wordpress/extension.neon'];
+        return [
+            dirname(__DIR__) . '/vendor/szepeviktor/phpstan-wordpress/extension.neon',
+            __DIR__ . '/test-services.neon',
+        ];
     }
 }

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -11,6 +11,14 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
      */
     public function dataFileAsserts(): iterable
     {
+        $phpstanVersion = self::getContainer()->getByType(InstalledPhpStanVersion::class);
+
+        if ($phpstanVersion->satisfies('^2.1.18')) {
+            // Improved rtrim handling in PHPStan 2.1.18 gives different results
+            yield from self::gatherAssertTypes(__DIR__ . '/data/slashit-functions.php');
+        }
+
+        // Include for all supported PHPStan versions
         yield from self::gatherAssertTypes(__DIR__ . '/data/apply-filters.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/ApplyFiltersTestClass.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/esc-sql.php');
@@ -19,13 +27,6 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from self::gatherAssertTypes(__DIR__ . '/data/stripslashes-from-strings-only.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp-parse-url.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp-slash.php');
-
-        $phpstanVersion = self::getContainer()->getByType(InstalledPhpStanVersion::class);
-
-        if ($phpstanVersion->satisfies('^2.1.18')) {
-            // Improved rtrim handling in PHPStan 2.1.18 gives different results
-            yield from self::gatherAssertTypes(__DIR__ . '/data/slashit-functions.php');
-        }
     }
 
     /**

--- a/tests/InstalledPhpStanVersion.php
+++ b/tests/InstalledPhpStanVersion.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use Composer\InstalledVersions;
+use Composer\Semver\Semver;
+
+final class InstalledPhpStanVersion
+{
+    private string $version;
+
+    public function __construct()
+    {
+        $version = InstalledVersions::getVersion('phpstan/phpstan-src');
+
+        if ($version === null) {
+            throw new \RuntimeException('Cannot determine PHPStan version from Composer.');
+        }
+
+        $this->version = $version;
+    }
+
+    public function satisfies(string $constraints): bool
+    {
+        return Semver::satisfies($this->version, $constraints);
+    }
+}

--- a/tests/test-services.neon
+++ b/tests/test-services.neon
@@ -1,0 +1,3 @@
+services:
+    -
+        class: SzepeViktor\PHPStan\WordPress\Tests\InstalledPhpStanVersion


### PR DESCRIPTION
Types may depend on the PHPStan version used--especially when a dynamic return type extension relies on types inferred by PHPStan.

Example from `SlashitFunctionsDynamicFunctionReturnTypeExtension`, where the type depends on PHPStan’s handling of `rtrim()`:
https://github.com/szepeviktor/phpstan-wordpress/blob/1cdb6d5a1951904daf8d54df3f40e2fc5df45bce/src/SlashitFunctionsDynamicFunctionReturnTypeExtension.php#L62

Among other cases, this can cause tests to fail in the [lowest-deps](https://github.com/szepeviktor/phpstan-wordpress/blob/1cdb6d5a1951904daf8d54df3f40e2fc5df45bce/.travis.yml#L31-L38) build. To avoid bumping the required PHPStan version, this PR introduces the `InstalledPhpStanVersion` class and uses it in `DynamicReturnTypeExtensionTest` to avoid gathering types for versions that produce different results than the latest.

The types returned in the lowest supported version should still be checked to rule out incorrect cases. This has been done for `data/slashit-functions.php`. We could also add, e.g., `data/slashit-functions-bc.php` with assertions that pass with the lowest PHPStan version. This has not been done yet.
