### PR TITLE
Add WP_START_TIMESTAMP constant

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -16,6 +16,7 @@ define('EMPTY_TRASH_DAYS', 30);
 define('SCRIPT_DEBUG', false);
 define('WP_LANG_DIR', sprintf('%s/languages', WP_CONTENT_DIR));
 define('COOKIE_DOMAIN', '');
+define('WP_START_TIMESTAMP', microtime(true));
 
 // Constants for expressing human-readable intervals.
 define('MINUTE_IN_SECONDS', 60);

--- a/extension.neon
+++ b/extension.neon
@@ -71,6 +71,7 @@ parameters:
         - COOKIE_DOMAIN
         - EMPTY_TRASH_DAYS
         - SCRIPT_DEBUG
+        - WP_START_TIMESTAMP
     earlyTerminatingFunctionCalls:
         - wp_send_json
         - wp_nonce_ays


### PR DESCRIPTION
`WP_START_TIMESTAMP` is a default WordPress constant defined in `wp-includes/default-constants.php` which was missing in this stub. This PR adds it so that phpstan can be used for code relying on that constant without having to exclude the rule.