### PR TITLE
Adjust the wordpress-stubs dependency version range so version 7.0 can be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "php-stubs/wordpress-stubs": "^6.6.2",
+        "php-stubs/wordpress-stubs": ">=6.6.2",
         "phpstan/phpstan": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Attempting to install this package alongside `php-stubs/wordpress-stubs` at version 7.0.0 results in an unresolvable dependency, because this package depends on `php-stubs/wordpress-stubs` with `^6.6.2`, which `7.0.0` does not satisfy.

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires szepeviktor/phpstan-wordpress 2.0.3 -> satisfiable by szepeviktor/phpstan-wordpress[v2.0.3].
    - szepeviktor/phpstan-wordpress v2.0.3 requires php-stubs/wordpress-stubs ^6.6.2 -> found php-stubs/wordpress-stubs[v6.6.2, ..., v6.9.4] but it conflicts with your root composer.json require (7.0.0).
```

This fixes that.