### PR TITLE
Add a dynamic return type extension for `wp_parse_args()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpstan/phpstan-strict-rules": "^1.2",
         "phpunit/phpunit": "^8.0 || ^9.0",
         "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
-        "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+        "wp-coding-standards/wpcs": "3.4.1 as 2.3.0"
     },
     "suggest": {
         "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"

--- a/extension.neon
+++ b/extension.neon
@@ -98,6 +98,10 @@ services:
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension
     -
+        class: SzepeViktor\PHPStan\WordPress\WpParseArgsDynamicFunctionReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicFunctionReturnTypeExtension
+    -
         class: SzepeViktor\PHPStan\WordPress\WpParseUrlFunctionDynamicReturnTypeExtension
         tags:
             - phpstan.broker.dynamicFunctionReturnTypeExtension

--- a/src/WpParseArgsDynamicFunctionReturnTypeExtension.php
+++ b/src/WpParseArgsDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Set return type of wp_parse_args().
+ */
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+final class WpParseArgsDynamicFunctionReturnTypeExtension implements \PHPStan\Type\DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        return $functionReflection->getName() === 'wp_parse_args';
+    }
+
+    /**
+     * @see https://developer.wordpress.org/reference/functions/wp_parse_args/
+     *
+     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter
+     */
+    public function getTypeFromFunctionCall(FunctionReflection $functionReflection, FuncCall $functionCall, Scope $scope): ?Type
+    {
+        $args = $functionCall->getArgs();
+
+        if ($args === []) {
+            return null;
+        }
+
+        // Unpacked arguments are not matched up with the parameters here.
+        foreach ($args as $arg) {
+            if ($arg->unpack) {
+                return null;
+            }
+        }
+
+        // wp_parse_args() first turns its arguments into an array: an array is taken as it is,
+        // an object is converted with get_object_vars(), and anything else is parsed as a query
+        // string, which results in a shape we cannot describe.
+        $parsed = self::getParsedArgsExpr($args[0]->value, $scope);
+
+        if (! $parsed instanceof Expr) {
+            return null;
+        }
+
+        $parsedType = $scope->getType($parsed);
+
+        if (! isset($args[1])) {
+            return $parsedType;
+        }
+
+        $defaultsType = $scope->getType($args[1]->value);
+
+        // Defaults that are not an array are ignored, the parsed arguments are returned as they are.
+        if ($defaultsType->isArray()->no()) {
+            return $parsedType;
+        }
+
+        if (! $defaultsType->isArray()->yes()) {
+            return null;
+        }
+
+        // The parsed arguments are merged over the defaults, which is what array_merge() does.
+        $mergedType = $scope->getType(
+            new FuncCall(
+                new Name('array_merge'),
+                [new Arg($args[1]->value), new Arg($parsed)]
+            )
+        );
+
+        // Empty defaults are skipped, so the parsed arguments keep their own keys in that case.
+        if ($defaultsType->isIterableAtLeastOnce()->yes()) {
+            return $mergedType;
+        }
+
+        return TypeCombinator::union($mergedType, $parsedType);
+    }
+
+    private static function getParsedArgsExpr(Expr $argsExpr, Scope $scope): ?Expr
+    {
+        $argsType = $scope->getType($argsExpr);
+
+        if ($argsType->isArray()->yes()) {
+            return $argsExpr;
+        }
+
+        if ($argsType->isObject()->yes()) {
+            return new FuncCall(new Name('get_object_vars'), [new Arg($argsExpr)]);
+        }
+
+        return null;
+    }
+}

--- a/src/WpParseArgsDynamicFunctionReturnTypeExtension.php
+++ b/src/WpParseArgsDynamicFunctionReturnTypeExtension.php
@@ -94,7 +94,10 @@ final class WpParseArgsDynamicFunctionReturnTypeExtension implements \PHPStan\Ty
             return $argsExpr;
         }
 
-        if ($argsType->isObject()->yes()) {
+        // wp_parse_args() is a global function, so the get_object_vars() inside it only ever
+        // sees public properties. The synthetic call below is resolved in the caller's scope,
+        // which inside a class can see more than that, so it is only safe out of class scope.
+        if ($argsType->isObject()->yes() && ! $scope->isInClass()) {
             return new FuncCall(new Name('get_object_vars'), [new Arg($argsExpr)]);
         }
 

--- a/tests/DynamicReturnTypeExtensionTest.php
+++ b/tests/DynamicReturnTypeExtensionTest.php
@@ -32,6 +32,7 @@ class DynamicReturnTypeExtensionTest extends \PHPStan\Testing\TypeInferenceTestC
         yield from self::gatherAssertTypes(__DIR__ . '/data/shortcode_atts.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/term_exists.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp_error_parameter.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/wp_parse_args.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp_parse_url.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp_die.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/wp_theme_get.php');

--- a/tests/data/wp_parse_args.php
+++ b/tests/data/wp_parse_args.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SzepeViktor\PHPStan\WordPress\Tests;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * The whole point of wp_parse_args() is that every default key is present in the
+ * result, so optional keys of the given arguments become required ones.
+ *
+ * @param array{before?: string, after?: string, echo?: bool} $args
+ */
+function wpParseArgsWithShape(array $args): void
+{
+    assertType(
+        'array{before: string, after: string, echo: bool}',
+        wp_parse_args($args, ['before' => '', 'after' => '', 'echo' => true])
+    );
+}
+
+/**
+ * Arguments take precedence over the defaults they overwrite.
+ */
+function wpParseArgsWithConstantArrays(): void
+{
+    assertType("array{a: 1, b: 'y'}", wp_parse_args(['a' => 1], ['a' => 'x', 'b' => 'y']));
+}
+
+/**
+ * Empty defaults are skipped by wp_parse_args(), which returns the arguments unchanged.
+ *
+ * @param array{page?: int} $args
+ */
+function wpParseArgsWithoutDefaults(array $args): void
+{
+    assertType('array{page?: int}', wp_parse_args($args));
+    assertType('array{page?: int}', wp_parse_args($args, []));
+}
+
+/**
+ * Defaults that are not an array are ignored, just like an empty array.
+ *
+ * @param array{page?: int} $args
+ */
+function wpParseArgsWithNonArrayDefaults(array $args, string $defaults): void
+{
+    assertType('array{page?: int}', wp_parse_args($args, $defaults));
+}
+
+/**
+ * Defaults that may or may not be empty can only guarantee the keys of the arguments.
+ *
+ * @param array{page?: int} $args
+ */
+function wpParseArgsWithMaybeEmptyDefaults(array $args, bool $condition): void
+{
+    $defaults = $condition ? [] : ['page' => 1];
+
+    assertType('array{page?: int}', wp_parse_args($args, $defaults));
+}
+
+/**
+ * Objects are converted to an array of their properties before the defaults are merged in.
+ */
+function wpParseArgsWithObject(\WP_Post $post): void
+{
+    assertType('non-empty-array<string, mixed>', wp_parse_args($post, ['extra' => 1]));
+}
+
+/**
+ * A query string cannot be described, so the declared return type is kept.
+ */
+function wpParseArgsWithString(string $query): void
+{
+    assertType('array', wp_parse_args($query, ['page' => 1]));
+}

--- a/tests/data/wp_parse_args.php
+++ b/tests/data/wp_parse_args.php
@@ -70,6 +70,21 @@ function wpParseArgsWithObject(\WP_Post $post): void
 }
 
 /**
+ * Inside a class the caller can see more properties than the global wp_parse_args()
+ * can, so the object is not converted there and the declared return type is kept.
+ */
+class WpParseArgsInsideAClass
+{
+    /** @var int */
+    public $number = 1;
+
+    public function parse(): void
+    {
+        assertType('array', wp_parse_args($this, ['number' => 2]));
+    }
+}
+
+/**
  * A query string cannot be described, so the declared return type is kept.
  */
 function wpParseArgsWithString(string $query): void


### PR DESCRIPTION
wp_parse_args() is documented as returning a plain `array`, so every value read out of it is `mixed`. The function merges the parsed arguments over the defaults with array_merge(), which is enough to describe precisely:

- optional keys of the given arguments become required, because the defaults always supply them;
- a value given in the arguments takes precedence over its default;
- empty (or non-array) defaults are skipped, so the arguments are returned as they are;
- an object argument is converted with get_object_vars() first, and a query string cannot be described, so the declared return type is kept there.

See #274